### PR TITLE
fix: fix deadletter count metric bug

### DIFF
--- a/actor/pid.go
+++ b/actor/pid.go
@@ -1891,7 +1891,7 @@ func (pid *PID) suspend(reason string) {
 // getDeadlettersCount gets deadletter
 func (pid *PID) getDeadlettersCount(ctx context.Context) int64 {
 	var (
-		name    = pid.Name()
+		name    = pid.ID()
 		to      = pid.ActorSystem().getDeadletter()
 		from    = pid.ActorSystem().getSystemGuardian()
 		message = &internalpb.GetDeadlettersCount{

--- a/actor/pid_test.go
+++ b/actor/pid_test.go
@@ -3709,3 +3709,39 @@ func TestLogger(t *testing.T) {
 		buffer.Reset()
 	})
 }
+func TestDeadletterCountMetric(t *testing.T) {
+	ctx := context.TODO()
+	sys, _ := NewActorSystem("testSys", WithLogger(log.DiscardLogger))
+
+	// start the actor system
+	err := sys.Start(ctx)
+	assert.NoError(t, err)
+
+	// wait for complete start
+	util.Pause(time.Second)
+
+	// create the black hole actor
+	actor := &mockUnhandledMessageActor{}
+	actorName := "actorName"
+	actorRef, err := sys.Spawn(ctx, actorName, actor)
+	assert.NoError(t, err)
+	assert.NotNil(t, actorRef)
+
+	// wait a while
+	util.Pause(time.Second)
+
+	// every message sent to the actor will result in deadletter
+	for i := 0; i < 5; i++ {
+		require.NoError(t, Tell(ctx, actorRef, new(testpb.TestSend)))
+	}
+
+	util.Pause(time.Second)
+
+	metric := actorRef.Metric(ctx)
+	require.NotNil(t, metric)
+
+	require.EqualValues(t, 5, metric.DeadlettersCount())
+
+	err = sys.Stop(ctx)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
The current implement always returns zero due to wrong actor ID reference in the code.