### PR TITLE
feat: redesign PreStart and PostStop hook to accept a Context

### DIFF
--- a/actor/actor.go
+++ b/actor/actor.go
@@ -42,7 +42,7 @@ package actor
 // **Supervision and Fault Tolerance**
 // If an actor fails during message processing, its supervisor can decide how to handle the failure
 // (e.g., restart, stop, escalate). If state recovery is needed (e.g., for persistent actors), it must
-// be explicitly handled inside the PreStart hook, typically in response to a PostStart system message.
+// be explicitly handled inside the PreStart hook.
 //
 // **Clustering and Remoting**
 // In a distributed deployment, actors can be remotely spawned, communicated with across nodes.

--- a/actor/actor.go
+++ b/actor/actor.go
@@ -24,10 +24,6 @@
 
 package actor
 
-import (
-	"context"
-)
-
 // Actor defines the interface that all actors in the system must implement.
 //
 // Actors are lightweight, concurrent, and isolated units of computation that
@@ -46,7 +42,7 @@ import (
 // **Supervision and Fault Tolerance**
 // If an actor fails during message processing, its supervisor can decide how to handle the failure
 // (e.g., restart, stop, escalate). If state recovery is needed (e.g., for persistent actors), it must
-// be explicitly handled inside Receive, typically in response to a PostStart system message.
+// be explicitly handled inside the PreStart hook, typically in response to a PostStart system message.
 //
 // **Clustering and Remoting**
 // In a distributed deployment, actors can be remotely spawned, communicated with across nodes.
@@ -56,12 +52,9 @@ type Actor interface {
 	// PreStart is called once before the actor starts processing messages.
 	//
 	// Use this method to initialize dependencies such as database clients,
-	// caches, or external service connections. If PreStart returns an error,
+	// caches, or external service connections and persistent state recovery. If PreStart returns an error,
 	// the actor will not be started, and the failure will be handled by its supervisor.
-	//
-	// Important: Persistent actors should not attempt recovery here. Instead,
-	// listen for the PostStart system message inside Receive to trigger recovery logic.
-	PreStart(ctx context.Context) error
+	PreStart(ctx *Context) error
 
 	// Receive handles all messages sent to the actor's mailbox.
 	//
@@ -89,5 +82,5 @@ type Actor interface {
 	//
 	// Note: If PostStop returns an error, the error is logged but does not prevent the actor
 	// from being stopped. Keep PostStop logic fast and resilient to avoid delaying system shutdowns.
-	PostStop(ctx context.Context) error
+	PostStop(ctx *Context) error
 }

--- a/actor/cluster_singleton.go
+++ b/actor/cluster_singleton.go
@@ -53,7 +53,7 @@ func newClusterSingletonManager() Actor {
 }
 
 // PreStart implements the pre-start hook.
-func (x *clusterSingletonManager) PreStart(context.Context) error {
+func (x *clusterSingletonManager) PreStart(*Context) error {
 	return nil
 }
 
@@ -68,7 +68,7 @@ func (x *clusterSingletonManager) Receive(ctx *ReceiveContext) {
 }
 
 // PostStop implements the post-stop hook.
-func (x *clusterSingletonManager) PostStop(context.Context) error {
+func (x *clusterSingletonManager) PostStop(*Context) error {
 	x.logger.Infof("%s stopped successfully", x.pid.Name())
 	return nil
 }

--- a/actor/context.go
+++ b/actor/context.go
@@ -1,0 +1,114 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2025  Arsene Tochemey Gandote
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package actor
+
+import (
+	"context"
+
+	"github.com/tochemey/goakt/v3/extension"
+)
+
+// Context provides an environment for an actor when it is about to start.
+//
+// It embeds the standard context.Context interface and grants access to the ActorSystem
+// that manages the actor's lifecycle.
+//
+// Use Context to:
+//   - Access the actor's system-wide services and dependencies.
+//   - Retrieve deadlines, cancellation signals, and request-scoped values
+//     through the embedded context.Context.
+//
+// A Context is guaranteed to be available during the actor’s initialization phase
+// and should be treated as immutable.
+type Context struct {
+	ctx         context.Context
+	actorSystem ActorSystem
+	actorName   string
+}
+
+// newContext creates and returns a new Context instance.
+//
+// It wraps the provided context.Context and associates it with the specified ActorSystem.
+func newContext(ctx context.Context, actorName string, actorSystem ActorSystem) *Context {
+	return &Context{
+		ctx:         ctx,
+		actorSystem: actorSystem,
+		actorName:   actorName,
+	}
+}
+
+// Context returns the underlying context associated with the actor's initialization.
+//
+// It carries deadlines, cancellation signals, and request-scoped values.
+// This method allows direct access to standard context operations.
+func (x *Context) Context() context.Context {
+	return x.ctx
+}
+
+// ActorSystem returns the ActorSystem that manages the actor.
+//
+// It provides access to system-level services, configuration, and infrastructure components
+// that the actor may interact with during its lifecycle.
+func (x *Context) ActorSystem() ActorSystem {
+	return x.actorSystem
+}
+
+// Extensions returns a slice of all extensions registered within the ActorSystem
+// associated with the Context.
+//
+// This allows system-level introspection or iteration over all available extensions.
+// It can be useful for message processing.
+//
+// Returns:
+//   - []extension.Extension: All registered extensions in the ActorSystem.
+func (x *Context) Extensions() []extension.Extension {
+	return x.ActorSystem().Extensions()
+}
+
+// Extension retrieves a specific extension registered in the ActorSystem by its unique ID.
+//
+// This allows actors to access shared functionality injected into the system, such as
+// event sourcing, metrics, tracing, or custom application services, directly from the Context.
+//
+// Example:
+//
+//	logger := x.Extension("extensionID").(MyExtension)
+//
+// Parameters:
+//   - extensionID: A unique string identifier used when the extension was registered.
+//
+// Returns:
+//   - extension.Extension: The corresponding extension if found, or nil otherwise.
+func (x *Context) Extension(extensionID string) extension.Extension {
+	return x.ActorSystem().Extension(extensionID)
+}
+
+// ActorName returns the name of the actor associated with this Context.
+//
+// The actor name is a unique string within the actor system, typically used for
+// identification, logging, monitoring, and message routing purposes.
+func (x *Context) ActorName() string {
+	return x.actorName
+}

--- a/actor/context_test.go
+++ b/actor/context_test.go
@@ -45,6 +45,8 @@ func TestContext(t *testing.T) {
 	require.Equal(t, "testSys", c.ActorSystem().Name())
 	require.Empty(t, c.ActorSystem().Actors())
 	require.NotNil(t, c.ActorSystem().Logger())
+	require.Empty(t, c.Extensions())
+	require.Nil(t, c.Extension("extensionID"))
 
 	dl, ok := c.Context().Deadline()
 	require.False(t, ok)

--- a/actor/context_test.go
+++ b/actor/context_test.go
@@ -22,33 +22,36 @@
  * SOFTWARE.
  */
 
-package bench
+package actor
 
 import (
-	actors "github.com/tochemey/goakt/v3/actor"
-	"github.com/tochemey/goakt/v3/bench/benchpb"
-	"github.com/tochemey/goakt/v3/goaktpb"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tochemey/goakt/v3/log"
 )
 
-type Actor struct {
-}
+func TestContext(t *testing.T) {
+	ctx := context.Background()
 
-func (p *Actor) PreStart(*actors.Context) error {
-	return nil
-}
+	actorSystem, err := NewActorSystem("testSys", WithLogger(log.DiscardLogger))
+	require.NoError(t, err)
+	require.NotNil(t, actorSystem)
 
-func (p *Actor) Receive(ctx *actors.ReceiveContext) {
-	switch ctx.Message().(type) {
-	case *goaktpb.PostStart:
-	case *benchpb.BenchTell:
-	case *benchpb.BenchRequest:
-		ctx.Response(&benchpb.BenchResponse{})
-	case *benchpb.BenchPriorityMailbox:
-	default:
-		ctx.Unhandled()
-	}
-}
+	c := newContext(ctx, "name", actorSystem)
+	require.NotNil(t, c.ActorSystem())
+	require.Equal(t, "testSys", c.ActorSystem().Name())
+	require.Empty(t, c.ActorSystem().Actors())
+	require.NotNil(t, c.ActorSystem().Logger())
 
-func (p *Actor) PostStop(*actors.Context) error {
-	return nil
+	dl, ok := c.Context().Deadline()
+	require.False(t, ok)
+	require.Zero(t, dl)
+	require.Equal(t, "name", c.ActorName())
+
+	done := c.Context().Done()
+	require.Nil(t, done)
+	require.NoError(t, c.Context().Err())
 }

--- a/actor/dead_letter.go
+++ b/actor/dead_letter.go
@@ -25,8 +25,6 @@
 package actor
 
 import (
-	"context"
-
 	"go.uber.org/atomic"
 
 	"github.com/tochemey/goakt/v3/address"
@@ -62,7 +60,7 @@ func newDeadLetter() *deadLetter {
 }
 
 // PreStart pre-starts the deadletter actor
-func (x *deadLetter) PreStart(context.Context) error {
+func (x *deadLetter) PreStart(*Context) error {
 	return nil
 }
 
@@ -86,7 +84,7 @@ func (x *deadLetter) Receive(ctx *ReceiveContext) {
 }
 
 // PostStop handles post procedures
-func (x *deadLetter) PostStop(context.Context) error {
+func (x *deadLetter) PostStop(*Context) error {
 	x.logger.Infof("%s stopped successfully", x.pid.Name())
 	return nil
 }

--- a/actor/death_watch.go
+++ b/actor/death_watch.go
@@ -51,7 +51,7 @@ func newDeathWatch() *deathWatch {
 }
 
 // PreStart is the pre-start hook
-func (x *deathWatch) PreStart(context.Context) error {
+func (x *deathWatch) PreStart(*Context) error {
 	return nil
 }
 
@@ -68,7 +68,7 @@ func (x *deathWatch) Receive(ctx *ReceiveContext) {
 }
 
 // PostStop is executed when the actor is shutting down.
-func (x *deathWatch) PostStop(context.Context) error {
+func (x *deathWatch) PostStop(*Context) error {
 	x.logger.Infof("%s stopped successfully", x.pid.Name())
 	return nil
 }

--- a/actor/func_actor.go
+++ b/actor/func_actor.go
@@ -115,11 +115,11 @@ func newFuncActor(id string, receiveFunc ReceiveFunc, config *funcConfig) *FuncA
 var _ Actor = (*FuncActor)(nil)
 
 // PreStart pre-starts the actor.
-func (x *FuncActor) PreStart(ctx context.Context) error {
+func (x *FuncActor) PreStart(ctx *Context) error {
 	// check whether the pre-start hook is set and call it
 	preStart := x.config.preStart
 	if preStart != nil {
-		return preStart(ctx)
+		return preStart(ctx.Context())
 	}
 	return nil
 }
@@ -138,11 +138,11 @@ func (x *FuncActor) Receive(ctx *ReceiveContext) {
 }
 
 // PostStop is executed when the actor is shutting down.
-func (x *FuncActor) PostStop(ctx context.Context) error {
+func (x *FuncActor) PostStop(ctx *Context) error {
 	// check whether the post-stop hook is set and call it
 	postStop := x.config.postStop
 	if postStop != nil {
-		return postStop(ctx)
+		return postStop(ctx.Context())
 	}
 	return nil
 }

--- a/actor/mock_test.go
+++ b/actor/mock_test.go
@@ -63,7 +63,7 @@ func newMockSubscriber() *mockSubscriber {
 	}
 }
 
-func (x *mockSubscriber) PreStart(context.Context) error {
+func (x *mockSubscriber) PreStart(*Context) error {
 	return nil
 }
 
@@ -78,13 +78,12 @@ func (x *mockSubscriber) Receive(ctx *ReceiveContext) {
 	}
 }
 
-func (x *mockSubscriber) PostStop(context.Context) error {
+func (x *mockSubscriber) PostStop(*Context) error {
 	return nil
 }
 
 // mockActor is an actor that helps run various test scenarios
-type mockActor struct {
-}
+type mockActor struct{}
 
 // enforce compilation error
 var _ Actor = (*mockActor)(nil)
@@ -96,12 +95,12 @@ func newMockActor() *mockActor {
 
 // Init initialize the actor. This function can be used to set up some database connections
 // or some sort of initialization before the actor init processing message
-func (p *mockActor) PreStart(context.Context) error {
+func (p *mockActor) PreStart(*Context) error {
 	return nil
 }
 
 // Shutdown gracefully shuts down the given actor
-func (p *mockActor) PostStop(context.Context) error {
+func (p *mockActor) PostStop(*Context) error {
 	return nil
 }
 
@@ -141,7 +140,7 @@ func newMockSupervisorActor() *mockSupervisorActor {
 	return &mockSupervisorActor{}
 }
 
-func (p *mockSupervisorActor) PreStart(context.Context) error {
+func (p *mockSupervisorActor) PreStart(*Context) error {
 	return nil
 }
 
@@ -156,7 +155,7 @@ func (p *mockSupervisorActor) Receive(ctx *ReceiveContext) {
 	}
 }
 
-func (p *mockSupervisorActor) PostStop(context.Context) error {
+func (p *mockSupervisorActor) PostStop(*Context) error {
 	return nil
 }
 
@@ -171,7 +170,7 @@ func newMockSupervisedActor() *mockSupervisedActor {
 	return &mockSupervisedActor{}
 }
 
-func (x *mockSupervisedActor) PreStart(context.Context) error {
+func (x *mockSupervisedActor) PreStart(*Context) error {
 	return nil
 }
 
@@ -190,7 +189,7 @@ func (x *mockSupervisedActor) Receive(ctx *ReceiveContext) {
 	}
 }
 
-func (x *mockSupervisedActor) PostStop(context.Context) error {
+func (x *mockSupervisedActor) PostStop(*Context) error {
 	return nil
 }
 
@@ -200,11 +199,11 @@ type mockBehaviorActor struct{}
 // enforce compilation error
 var _ Actor = &mockBehaviorActor{}
 
-func (x *mockBehaviorActor) PreStart(_ context.Context) error {
+func (x *mockBehaviorActor) PreStart(*Context) error {
 	return nil
 }
 
-func (x *mockBehaviorActor) PostStop(_ context.Context) error {
+func (x *mockBehaviorActor) PostStop(*Context) error {
 	return nil
 }
 
@@ -251,7 +250,7 @@ type exchanger struct {
 	id string
 }
 
-func (e *exchanger) PreStart(context.Context) error {
+func (e *exchanger) PreStart(*Context) error {
 	return nil
 }
 
@@ -272,7 +271,7 @@ func (e *exchanger) Receive(ctx *ReceiveContext) {
 	}
 }
 
-func (e *exchanger) PostStop(context.Context) error {
+func (e *exchanger) PostStop(*Context) error {
 	return nil
 }
 
@@ -280,7 +279,7 @@ var _ Actor = &exchanger{}
 
 type mockStashActor struct{}
 
-func (x *mockStashActor) PreStart(context.Context) error {
+func (x *mockStashActor) PreStart(*Context) error {
 	return nil
 }
 
@@ -312,7 +311,7 @@ func (x *mockStashActor) Ready(ctx *ReceiveContext) {
 	}
 }
 
-func (x *mockStashActor) PostStop(context.Context) error {
+func (x *mockStashActor) PostStop(*Context) error {
 	return nil
 }
 
@@ -320,13 +319,13 @@ var _ Actor = &mockStashActor{}
 
 type mockPreStartActor struct{}
 
-func (x *mockPreStartActor) PreStart(context.Context) error {
+func (x *mockPreStartActor) PreStart(*Context) error {
 	return errors.New("failed")
 }
 
 func (x *mockPreStartActor) Receive(*ReceiveContext) {}
 
-func (x *mockPreStartActor) PostStop(context.Context) error {
+func (x *mockPreStartActor) PostStop(*Context) error {
 	return nil
 }
 
@@ -334,7 +333,7 @@ var _ Actor = &mockPreStartActor{}
 
 type mockPostStopActor struct{}
 
-func (x *mockPostStopActor) PreStart(context.Context) error {
+func (x *mockPostStopActor) PreStart(*Context) error {
 	return nil
 }
 
@@ -347,7 +346,7 @@ func (x *mockPostStopActor) Receive(ctx *ReceiveContext) {
 	}
 }
 
-func (x *mockPostStopActor) PostStop(context.Context) error {
+func (x *mockPostStopActor) PostStop(*Context) error {
 	return errors.New("failed")
 }
 
@@ -361,7 +360,7 @@ func newRestart() *mockRestartActor {
 	return &mockRestartActor{counter: atomic.NewInt64(0)}
 }
 
-func (x *mockRestartActor) PreStart(context.Context) error {
+func (x *mockRestartActor) PreStart(*Context) error {
 	// increment counter
 	x.counter.Inc()
 	// error when counter is greater than 1
@@ -374,7 +373,7 @@ func (x *mockRestartActor) PreStart(context.Context) error {
 func (x *mockRestartActor) Receive(*ReceiveContext) {
 }
 
-func (x *mockRestartActor) PostStop(context.Context) error {
+func (x *mockRestartActor) PostStop(*Context) error {
 	return nil
 }
 
@@ -385,7 +384,7 @@ type mockForwardActor struct {
 	remoteRef *PID
 }
 
-func (x *mockForwardActor) PreStart(context.Context) error {
+func (x *mockForwardActor) PreStart(*Context) error {
 	return nil
 }
 
@@ -399,14 +398,14 @@ func (x *mockForwardActor) Receive(ctx *ReceiveContext) {
 	}
 }
 
-func (x *mockForwardActor) PostStop(context.Context) error {
+func (x *mockForwardActor) PostStop(*Context) error {
 	return nil
 }
 
 type mockRemoteActor struct {
 }
 
-func (x *mockRemoteActor) PreStart(context.Context) error {
+func (x *mockRemoteActor) PreStart(*Context) error {
 	return nil
 }
 
@@ -417,7 +416,7 @@ func (x *mockRemoteActor) Receive(ctx *ReceiveContext) {
 	}
 }
 
-func (x *mockRemoteActor) PostStop(context.Context) error {
+func (x *mockRemoteActor) PostStop(*Context) error {
 	return nil
 }
 
@@ -425,7 +424,7 @@ type mockUnhandledMessageActor struct{}
 
 var _ Actor = &mockUnhandledMessageActor{}
 
-func (d *mockUnhandledMessageActor) PreStart(context.Context) error {
+func (d *mockUnhandledMessageActor) PreStart(*Context) error {
 	return nil
 }
 
@@ -438,7 +437,7 @@ func (d *mockUnhandledMessageActor) Receive(ctx *ReceiveContext) {
 	}
 }
 
-func (d *mockUnhandledMessageActor) PostStop(context.Context) error {
+func (d *mockUnhandledMessageActor) PostStop(*Context) error {
 	return nil
 }
 
@@ -598,7 +597,7 @@ type mockRouterActor struct {
 
 var _ Actor = (*mockRouterActor)(nil)
 
-func (x *mockRouterActor) PreStart(context.Context) error {
+func (x *mockRouterActor) PreStart(*Context) error {
 	x.logger = log.DiscardLogger
 	return nil
 }
@@ -616,7 +615,7 @@ func (x *mockRouterActor) Receive(ctx *ReceiveContext) {
 	}
 }
 
-func (x *mockRouterActor) PostStop(context.Context) error {
+func (x *mockRouterActor) PostStop(*Context) error {
 	return nil
 }
 
@@ -687,12 +686,15 @@ func newMockEntity() *mockEntity {
 }
 
 // PreStart implements Actor.
-func (m *mockEntity) PreStart(context.Context) error {
-	return nil
+func (m *mockEntity) PreStart(ctx *Context) error {
+	m.currentState = atomic.NewPointer(new(testpb.Account))
+	m.stateStore = ctx.Extension("mockStateStore").(mockStateStore)
+	m.persistenceID = ctx.ActorName()
+	return m.recoverFromStore()
 }
 
 // PostStop implements Actor.
-func (m *mockEntity) PostStop(context.Context) error {
+func (m *mockEntity) PostStop(*Context) error {
 	return m.stateStore.WriteState(m.persistenceID, m.currentState.Load())
 }
 
@@ -700,14 +702,7 @@ func (m *mockEntity) PostStop(context.Context) error {
 func (m *mockEntity) Receive(ctx *ReceiveContext) {
 	switch received := ctx.Message().(type) {
 	case *goaktpb.PostStart:
-		m.persistenceID = ctx.Self().Name()
-		m.currentState = atomic.NewPointer[testpb.Account](new(testpb.Account))
-		m.stateStore = ctx.Extension("mockStateStore").(mockStateStore)
-		// recover state from state store
-		if err := m.recoverFromStore(); err != nil {
-			ctx.Err(err)
-			return
-		}
+		// pass
 	case *testpb.CreateAccount:
 		// TODO: in production extra validation will be needed.
 		balance := received.GetAccountBalance()

--- a/actor/rebalancer.go
+++ b/actor/rebalancer.go
@@ -59,7 +59,7 @@ func newRebalancer(reflection *reflection, remoting *Remoting) *rebalancer {
 }
 
 // PreStart pre-starts the actor.
-func (r *rebalancer) PreStart(context.Context) error {
+func (r *rebalancer) PreStart(*Context) error {
 	return nil
 }
 
@@ -158,7 +158,7 @@ func (r *rebalancer) Rebalance(ctx *ReceiveContext) {
 }
 
 // PostStop is executed when the actor is shutting down.
-func (r *rebalancer) PostStop(context.Context) error {
+func (r *rebalancer) PostStop(*Context) error {
 	r.remoting.Close()
 	r.logger.Infof("%s stopped successfully", r.pid.Name())
 	return nil

--- a/actor/receive_context.go
+++ b/actor/receive_context.go
@@ -56,7 +56,26 @@ func releaseContext(receiveContext *ReceiveContext) {
 	pool.Put(receiveContext)
 }
 
-// ReceiveContext is the context that is used by the actor to receive messages
+// ReceiveContext provides contextual information and operations
+// available to an actor when it is processing a message.
+//
+// It typically carries metadata about the incoming message,
+// offers control over the actor's lifecycle (e.g., stopping itself),
+// and gives access to messaging operations like sending a response,
+// forwarding the message, or spawning child actors.
+//
+// Implementations of ReceiveContext allow the actor's behavior
+// to be more declarative and consistent with the Actor Model.
+//
+// Example usage:
+//
+//	func (a *MyActor) Receive(ctx *actor.ReceiveContext) {
+//	    msg := ctx.Message()
+//	    switch msg := msg.(type) {
+//	    case *MyMessage:
+//	        ctx.Respond(&MyResponse{})
+//	    }
+//	}
 type ReceiveContext struct {
 	ctx          context.Context
 	message      proto.Message

--- a/actor/root_guardian.go
+++ b/actor/root_guardian.go
@@ -25,8 +25,6 @@
 package actor
 
 import (
-	"context"
-
 	"github.com/tochemey/goakt/v3/goaktpb"
 	"github.com/tochemey/goakt/v3/log"
 )
@@ -48,7 +46,7 @@ func newRootGuardian() *rootGuardian {
 }
 
 // PreStart pre-starts the actor.
-func (r *rootGuardian) PreStart(context.Context) error {
+func (r *rootGuardian) PreStart(*Context) error {
 	return nil
 }
 
@@ -68,7 +66,7 @@ func (r *rootGuardian) Receive(ctx *ReceiveContext) {
 }
 
 // PostStop is executed when the actor is shutting down.
-func (r *rootGuardian) PostStop(context.Context) error {
+func (r *rootGuardian) PostStop(*Context) error {
 	r.logger.Infof("%s stopped successfully", r.pid.Name())
 	return nil
 }

--- a/actor/router.go
+++ b/actor/router.go
@@ -25,7 +25,6 @@
 package actor
 
 import (
-	"context"
 	"fmt"
 	"math/rand/v2"
 	"reflect"
@@ -101,7 +100,7 @@ func newRouter(poolSize int, routeesKind Actor, loggger log.Logger, opts ...Rout
 }
 
 // PreStart pre-starts the actor.
-func (x *router) PreStart(context.Context) error {
+func (x *router) PreStart(*Context) error {
 	x.logger.Info("starting the router...")
 	return nil
 }
@@ -118,7 +117,7 @@ func (x *router) Receive(ctx *ReceiveContext) {
 }
 
 // PostStop is executed when the actor is shutting down.
-func (x *router) PostStop(context.Context) error {
+func (x *router) PostStop(*Context) error {
 	x.logger.Info("router stopped")
 	return nil
 }

--- a/actor/system_guardian.go
+++ b/actor/system_guardian.go
@@ -52,7 +52,7 @@ func newSystemGuardian() *systemGuardian {
 }
 
 // PreStart is the pre-start hook
-func (x *systemGuardian) PreStart(context.Context) error {
+func (x *systemGuardian) PreStart(*Context) error {
 	return nil
 }
 
@@ -72,7 +72,7 @@ func (x *systemGuardian) Receive(ctx *ReceiveContext) {
 }
 
 // PostStop is the post-stop hook
-func (x *systemGuardian) PostStop(context.Context) error {
+func (x *systemGuardian) PostStop(*Context) error {
 	x.logger.Infof("%s stopped successfully", x.pid.Name())
 	return nil
 }

--- a/actor/topic_actor.go
+++ b/actor/topic_actor.go
@@ -78,7 +78,7 @@ func newTopicActor(remoting *Remoting) Actor {
 }
 
 // PreStart is called before the actor starts
-func (x *topicActor) PreStart(context.Context) error {
+func (x *topicActor) PreStart(*Context) error {
 	x.topics.Reset()
 	x.processed.Reset()
 	return nil
@@ -103,7 +103,7 @@ func (x *topicActor) Receive(ctx *ReceiveContext) {
 }
 
 // PostStop is called when the actor is stopped
-func (x *topicActor) PostStop(context.Context) error {
+func (x *topicActor) PostStop(*Context) error {
 	x.topics.Reset()
 	x.processed.Reset()
 	x.logger.Infof("%s stopped successfully", x.pid.Name())

--- a/actor/user_guardian.go
+++ b/actor/user_guardian.go
@@ -25,8 +25,6 @@
 package actor
 
 import (
-	"context"
-
 	"github.com/tochemey/goakt/v3/goaktpb"
 	"github.com/tochemey/goakt/v3/log"
 )
@@ -49,7 +47,7 @@ func newUserGuardian() *userGuardian {
 }
 
 // PreStart is the pre-start hook
-func (x *userGuardian) PreStart(context.Context) error {
+func (x *userGuardian) PreStart(*Context) error {
 	return nil
 }
 
@@ -69,7 +67,7 @@ func (x *userGuardian) Receive(ctx *ReceiveContext) {
 }
 
 // PostStop is the post-stop hook
-func (x *userGuardian) PostStop(context.Context) error {
+func (x *userGuardian) PostStop(*Context) error {
 	x.logger.Infof("%s stopped successfully", x.pid.Name())
 	return nil
 }

--- a/bench/ping/ping.go
+++ b/bench/ping/ping.go
@@ -118,7 +118,7 @@ func NewPing(toSend []proto.Message) *Ping {
 	}
 }
 
-func (act *Ping) PreStart(context.Context) error {
+func (act *Ping) PreStart(*goakt.Context) error {
 	return nil
 }
 
@@ -136,6 +136,6 @@ func (act *Ping) Receive(ctx *goakt.ReceiveContext) {
 	}
 }
 
-func (act *Ping) PostStop(context.Context) error {
+func (act *Ping) PostStop(*goakt.Context) error {
 	return nil
 }

--- a/bench/pong/pong.go
+++ b/bench/pong/pong.go
@@ -107,7 +107,7 @@ func NewPong(expected int) *Pong {
 	}
 }
 
-func (act *Pong) PreStart(context.Context) error {
+func (act *Pong) PreStart(*goakt.Context) error {
 	return nil
 }
 
@@ -128,6 +128,6 @@ func (act *Pong) Receive(ctx *goakt.ReceiveContext) {
 	}
 }
 
-func (act *Pong) PostStop(context.Context) error {
+func (act *Pong) PostStop(*goakt.Context) error {
 	return nil
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -818,14 +818,14 @@ var _ actors.Actor = (*testActor)(nil)
 
 // Init initialize the actor. This function can be used to set up some database connections
 // or some sort of initialization before the actor init processing public
-func (p *testActor) PreStart(context.Context) error {
+func (p *testActor) PreStart(*actors.Context) error {
 	p.logger = log.DiscardLogger
 	p.logger.Info("pre start")
 	return nil
 }
 
 // Shutdown gracefully shuts down the given actor
-func (p *testActor) PostStop(context.Context) error {
+func (p *testActor) PostStop(*actors.Context) error {
 	p.logger.Info("post stop")
 	return nil
 }

--- a/testkit/probe.go
+++ b/testkit/probe.go
@@ -89,7 +89,7 @@ type probeActor struct {
 var _ actors.Actor = &probeActor{}
 
 // PreStart is called before the actor starts
-func (x *probeActor) PreStart(_ context.Context) error {
+func (x *probeActor) PreStart(_ *actors.Context) error {
 	return nil
 }
 
@@ -111,7 +111,7 @@ func (x *probeActor) Receive(ctx *actors.ReceiveContext) {
 }
 
 // PostStop handles stop routines
-func (x *probeActor) PostStop(_ context.Context) error {
+func (x *probeActor) PostStop(_ *actors.Context) error {
 	return nil
 }
 

--- a/testkit/probe_test.go
+++ b/testkit/probe_test.go
@@ -212,7 +212,7 @@ func TestTestProbe(t *testing.T) {
 type pinger struct {
 }
 
-func (t pinger) PreStart(_ context.Context) error {
+func (t pinger) PreStart(_ *actors.Context) error {
 	return nil
 }
 
@@ -237,7 +237,7 @@ func (t pinger) Receive(ctx *actors.ReceiveContext) {
 	}
 }
 
-func (t pinger) PostStop(_ context.Context) error {
+func (t pinger) PostStop(_ *actors.Context) error {
 	return nil
 }
 


### PR DESCRIPTION
BREAKING CHANGE: 

- `PreStart` now accepts `Context` instead of standard go context
- `PostStop` now accepts `Context` instead of standard go context