### PR TITLE
refactor: :sparkles: enable pub-sub support for both clustered and standalone modes

### DIFF
--- a/actor/option.go
+++ b/actor/option.go
@@ -175,15 +175,25 @@ func WithTLS(tlsInfo *TLSInfo) Option {
 	})
 }
 
-// WithPubSub enables the pubsub mode.
-// The pubsub mode is only available in cluster mode.
-// The pubsub mode allows actors to subscribe to topics and receive messages
-// published to the topics.
+// WithPubSub enables the pub-sub (publish-subscribe) mode for the actor system.
+//
+// In pub-sub mode, actors can subscribe to one or more named topics and receive
+// messages that are published to those topics. This is useful for implementing
+// decoupled communication patterns where the publisher does not need to know
+// the identity or number of subscribers.
+//
+// When this option is applied during system initialization, internal mechanisms
+// for managing topic subscriptions and broadcasting messages to subscribers
+// will be activated.
+//
+// Example:
+//
+//	system := NewActorSystem(WithPubSub())
+//
+// Returns an Option that configures the actor system accordingly.
 func WithPubSub() Option {
 	return OptionFunc(func(system *actorSystem) {
-		if system.clusterEnabled.Load() {
-			system.pubsubEnabled.Store(true)
-		}
+		system.pubsubEnabled.Store(true)
 	})
 }
 

--- a/actor/option_test.go
+++ b/actor/option_test.go
@@ -141,7 +141,6 @@ func TestWithCoordinatedShutdown(t *testing.T) {
 
 func TestWithPubSub(t *testing.T) {
 	system := new(actorSystem)
-	system.clusterEnabled.Store(true)
 	opt := WithPubSub()
 	opt.Apply(system)
 	assert.True(t, system.pubsubEnabled.Load())


### PR DESCRIPTION
PubSub functionality is now available regardless of whether the actor system
is running in cluster mode or not. This allows actors to subscribe to and
publish messages to topics in both distributed and single-node deployments.

- Ensured the topic actor works across modes
- Optimized message routing for clustered topic propagation
- Improved flexibility for deployment scenarios