### PR TITLE
fix: allow publish to topic without sender

### DIFF
--- a/actor/topic_actor.go
+++ b/actor/topic_actor.go
@@ -116,7 +116,11 @@ func (x *topicActor) handlePublish(ctx *ReceiveContext) {
 		topic := publish.GetTopic()
 		message := publish.GetMessage()
 		messageID := publish.GetId()
-		senderID := ctx.Sender().ID()
+
+		var senderID string
+		if sender := ctx.Sender(); sender != nil {
+			senderID = sender.ID()
+		}
 
 		id := key{
 			senderID:  senderID,

--- a/actor/topic_actor_test.go
+++ b/actor/topic_actor_test.go
@@ -319,7 +319,7 @@ func TestTopicActor(t *testing.T) {
 		require.EqualValues(t, 1, actor3.Metric(ctx).ProcessedCount())
 		require.EqualValues(t, 1, actor3.Actor().(*mockSubscriber).counter.Load())
 
-		// create a publisher that will publish messages to the topi
+		// create a publisher that will publish messages to the topic
 		publisher, err := actorSystem.Spawn(ctx, "publisher", newMockSubscriber())
 		require.NoError(t, err)
 		require.NotNil(t, publisher)
@@ -335,6 +335,84 @@ func TestTopicActor(t *testing.T) {
 			Message: transformed,
 		}
 		err = publisher.Tell(ctx, actorSystem.TopicActor(), message)
+		require.NoError(t, err)
+
+		util.Pause(time.Second)
+
+		// make sure we receive the subscribe ack message
+		require.EqualValues(t, 2, actor1.Actor().(*mockSubscriber).counter.Load())
+		require.EqualValues(t, 2, actor2.Actor().(*mockSubscriber).counter.Load())
+		require.EqualValues(t, 2, actor3.Actor().(*mockSubscriber).counter.Load())
+
+		require.NoError(t, actorSystem.Stop(ctx))
+	})
+
+	t.Run("Without a sender", func(t *testing.T) {
+		ctx := context.Background()
+		actorSystem, _ := NewActorSystem("testSys", WithLogger(log.DiscardLogger), WithPubSub())
+
+		// start the actor system
+		err := actorSystem.Start(ctx)
+		assert.NoError(t, err)
+
+		// wait for the actor system to be ready
+		util.Pause(time.Second)
+
+		// start bunch of actors
+		actor1, err := actorSystem.Spawn(ctx, "actor1", newMockSubscriber(), WithLongLived())
+		require.NoError(t, err)
+		require.NotNil(t, actor1)
+
+		util.Pause(500 * time.Millisecond)
+
+		actor2, err := actorSystem.Spawn(ctx, "actor2", newMockSubscriber(), WithLongLived())
+		require.NoError(t, err)
+		require.NotNil(t, actor2)
+
+		util.Pause(500 * time.Millisecond)
+
+		actor3, err := actorSystem.Spawn(ctx, "actor3", newMockSubscriber(), WithLongLived())
+		require.NoError(t, err)
+		require.NotNil(t, actor3)
+
+		util.Pause(500 * time.Millisecond)
+
+		topic := "test-topic"
+
+		// let the various actors subscribe to the topic
+		err = actor1.Tell(ctx, actorSystem.TopicActor(), &goaktpb.Subscribe{Topic: topic})
+		require.NoError(t, err)
+		util.Pause(500 * time.Millisecond)
+
+		// make sure we receive the subscribe ack message
+		require.EqualValues(t, 1, actor1.Metric(ctx).ProcessedCount())
+		require.EqualValues(t, 1, actor1.Actor().(*mockSubscriber).counter.Load())
+
+		err = actor2.Tell(ctx, actorSystem.TopicActor(), &goaktpb.Subscribe{Topic: topic})
+		require.NoError(t, err)
+		util.Pause(500 * time.Millisecond)
+
+		// make sure we receive the subscribe ack message
+		require.EqualValues(t, 1, actor2.Metric(ctx).ProcessedCount())
+		require.EqualValues(t, 1, actor2.Actor().(*mockSubscriber).counter.Load())
+
+		err = actor3.Tell(ctx, actorSystem.TopicActor(), &goaktpb.Subscribe{Topic: topic})
+		require.NoError(t, err)
+		util.Pause(500 * time.Millisecond)
+
+		// make sure we receive the subscribe ack message
+		require.EqualValues(t, 1, actor3.Metric(ctx).ProcessedCount())
+		require.EqualValues(t, 1, actor3.Actor().(*mockSubscriber).counter.Load())
+
+		// publish a message without a sender
+		actual := new(testpb.TestCount)
+		transformed, _ := anypb.New(actual)
+		message := &goaktpb.Publish{
+			Id:      "messsage1",
+			Topic:   topic,
+			Message: transformed,
+		}
+		err = Tell(ctx, actorSystem.TopicActor(), message) // no sender
 		require.NoError(t, err)
 
 		util.Pause(time.Second)


### PR DESCRIPTION
Publishing a message from an actor to a topic works fine:

```go
err := senderActorPid.Tell(ctx, topicActorPid, publishMessage)
```

But publishing anonymously was creating a panic that would shut down the actor system:

```go
import goakt "github.com/tochemey/goakt/v3/actor"

...

err := goakt.Tell(ctx, topicActorPid, publishMessage)
```

The panic was due to `ctx.Sender()` being `nil` in the `handlePublish` method.

Fixed.  Copied and modified one of the existing test, which would fail without the fix but now passes.