### PR TITLE
fix: receive context nil context

### DIFF
--- a/actor/receive_context.go
+++ b/actor/receive_context.go
@@ -544,6 +544,8 @@ func (rctx *ReceiveContext) build(ctx context.Context, from, to *PID, message pr
 		rctx.ctx = context.WithoutCancel(ctx)
 		return rctx
 	}
+
+	rctx.ctx = ctx
 	rctx.response = make(chan proto.Message, 1)
 	return rctx
 }


### PR DESCRIPTION
After updating to v3.6.1, I get a `nil` returned from `rctx.Context()` in the actor's `Receive` method, when the message is sent by `Ask`.

The `rctx.ctx` value should be set.