### PR TITLE
fix: spawn actor on cluster shouldn't warn or check type

### DIFF
--- a/actor/actor_system.go
+++ b/actor/actor_system.go
@@ -2921,16 +2921,11 @@ func (x *actorSystem) checkSpawnPreconditions(ctx context.Context, actorName str
 		}
 
 		// here we make sure in cluster mode that the given actor is uniquely created
-		// by checking both its kind and identifier
-		existed, err := x.cluster.GetActor(ctx, actorName)
+		exists, err := x.cluster.ActorExists(ctx, actorName)
 		if err != nil {
-			if errors.Is(err, cluster.ErrActorNotFound) {
-				return nil
-			}
 			return err
 		}
-
-		if existed.GetType() == types.Name(kind) {
+		if exists {
 			return NewErrActorAlreadyExists(actorName)
 		}
 	}

--- a/actor/death_watch_test.go
+++ b/actor/death_watch_test.go
@@ -90,7 +90,7 @@ func TestDeathWatch(t *testing.T) {
 		// mock the cluster interface
 		clmock := new(clustermock.Interface)
 		clmock.EXPECT().RemoveActor(mock.Anything, mock.Anything).Return(assert.AnError)
-		clmock.EXPECT().GetActor(mock.Anything, actorID).Return(nil, nil)
+		clmock.EXPECT().ActorExists(mock.Anything, actorID).Return(false, nil)
 
 		err = sys.Start(ctx)
 		require.NoError(t, err)

--- a/internal/cluster/engine_test.go
+++ b/internal/cluster/engine_test.go
@@ -157,6 +157,11 @@ func TestSingleNode(t *testing.T) {
 		err = cluster.PutActor(ctx, actor)
 		require.NoError(t, err)
 
+		// test the actor exists
+		exists, err := cluster.ActorExists(ctx, actorName)
+		require.NoError(t, err)
+		assert.True(t, exists)
+
 		// fetch the actor
 		actual, err := cluster.GetActor(ctx, actorName)
 		require.NoError(t, err)
@@ -164,11 +169,17 @@ func TestSingleNode(t *testing.T) {
 
 		assert.True(t, proto.Equal(actor, actual))
 
-		//  fetch non-existing actor
+		// test non-existing actor does not exist
 		fakeActorName := "fake"
+		exists, err = cluster.ActorExists(ctx, fakeActorName)
+		require.NoError(t, err)
+		assert.False(t, exists)
+
+		// fetch non-existing actor
 		actual, err = cluster.GetActor(ctx, fakeActorName)
 		require.Nil(t, actual)
-		assert.EqualError(t, err, ErrActorNotFound.Error())
+		assert.ErrorIs(t, err, ErrActorNotFound)
+
 		//  shutdown the Node startNode
 		util.Pause(time.Second)
 

--- a/mocks/cluster/interface.go
+++ b/mocks/cluster/interface.go
@@ -26,6 +26,63 @@ func (_m *Interface) EXPECT() *Interface_Expecter {
 	return &Interface_Expecter{mock: &_m.Mock}
 }
 
+// ActorExists provides a mock function with given fields: ctx, actorName
+func (_m *Interface) ActorExists(ctx context.Context, actorName string) (bool, error) {
+	ret := _m.Called(ctx, actorName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ActorExists")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return rf(ctx, actorName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = rf(ctx, actorName)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, actorName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Interface_ActorExists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ActorExists'
+type Interface_ActorExists_Call struct {
+	*mock.Call
+}
+
+// ActorExists is a helper method to define mock.On call
+//   - ctx context.Context
+//   - actorName string
+func (_e *Interface_Expecter) ActorExists(ctx interface{}, actorName interface{}) *Interface_ActorExists_Call {
+	return &Interface_ActorExists_Call{Call: _e.mock.On("ActorExists", ctx, actorName)}
+}
+
+func (_c *Interface_ActorExists_Call) Run(run func(ctx context.Context, actorName string)) *Interface_ActorExists_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *Interface_ActorExists_Call) Return(_a0 bool, _a1 error) *Interface_ActorExists_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Interface_ActorExists_Call) RunAndReturn(run func(context.Context, string) (bool, error)) *Interface_ActorExists_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Actors provides a mock function with given fields: ctx, timeout
 func (_m *Interface) Actors(ctx context.Context, timeout time.Duration) ([]*internalpb.Actor, error) {
 	ret := _m.Called(ctx, timeout)


### PR DESCRIPTION
When cluster mode is enabled, every time I spawn any actor, it checks the cluster first, which always logs a warning:

https://github.com/Tochemey/goakt/blob/bee36bdbb97f82ac3acbcad0c9624fb6d5e9825c/internal/cluster/engine.go#L583-L586

Instead of trying to retrieve the actor and expecting an error, we can just test if the actor exists or not, without retrieving it.

Additionally, we should only be testing for the actor name.  Previously, the check also tried to match the type and would allow it to be spawned it the types differed.  That's not valid, because one can't have two actors on the same cluster that have the same name and different types.