### PR TITLE
feat: pass actor system in shutdown hook

### DIFF
--- a/actor/actor_system.go
+++ b/actor/actor_system.go
@@ -2423,7 +2423,7 @@ func (x *actorSystem) shutdown(ctx context.Context) error {
 	// Run shutdown hooks and collect errors
 	var hooksErrs []error
 	for _, hook := range x.shutdownHooks {
-		if err := hook(ctx); err != nil {
+		if err := hook(ctx, x); err != nil {
 			x.logger.Errorf("shutdown hook execution failed: %v", err)
 			hooksErrs = append(hooksErrs, err)
 		}

--- a/actor/option.go
+++ b/actor/option.go
@@ -37,7 +37,7 @@ import (
 
 // ShutdownHook defines the shutdown hook to be executed alongside the
 // termination of the actor system
-type ShutdownHook func(ctx context.Context) error
+type ShutdownHook func(ctx context.Context, actorSystem ActorSystem) error
 
 // Option is the interface that applies a configuration option.
 type Option interface {

--- a/actor/option_test.go
+++ b/actor/option_test.go
@@ -123,7 +123,7 @@ func TestOption(t *testing.T) {
 
 func TestWithCoordinatedShutdown(t *testing.T) {
 	system := new(actorSystem)
-	shutdownHook := func(context.Context) error { return nil }
+	shutdownHook := func(context.Context, ActorSystem) error { return nil }
 	opt := WithCoordinatedShutdown(shutdownHook)
 	opt.Apply(system)
 	assert.EqualValues(t, 1, len(system.shutdownHooks))


### PR DESCRIPTION
This PR modifies the `ShutdownHook` function signature to include the actor system that is being shut down.
