### PR TITLE
Potential fix for code scanning alert no. 13: Incorrect conversion between integer types

### DIFF
--- a/address/address.go
+++ b/address/address.go
@@ -248,9 +248,10 @@ func Parse(addr string) (*Address, error) {
 	}
 	host := hostPortParts[0]
 	portStr := hostPortParts[1]
-	port, err := strconv.Atoi(portStr)
+	port64, err := strconv.ParseInt(portStr, 10, 32)
 	if err != nil {
 		return nil, err
 	}
+	port := int32(port64)
 	return New(name, system, host, port), nil
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Tochemey/goakt/security/code-scanning/13](https://github.com/Tochemey/goakt/security/code-scanning/13)

To fix the issue, we need to ensure that the `port` value is within the valid range for `int32` before performing the conversion. This can be achieved by adding bounds checks for the `port` value after parsing it with `strconv.Atoi`. Alternatively, we can use `strconv.ParseInt` with a bit size of 32 to directly parse the string into a value that fits within the `int32` range.

The best approach is to use `strconv.ParseInt` with a bit size of 32, as it simplifies the code and ensures the parsed value is already within the valid range for `int32`. If the parsed value exceeds the range, an error will be returned, and we can handle it appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
