### PR TITLE
Potential fix for code scanning alert no. 12: Incorrect conversion between integer types

### DIFF
--- a/actor/remoting.go
+++ b/actor/remoting.go
@@ -260,7 +260,12 @@ func (r *Remoting) RemoteSpawn(ctx context.Context, host string, port int, spawn
 	request := connect.NewRequest(
 		&internalpb.RemoteSpawnRequest{
 			Host:                host,
-			Port:                int32(port),
+			Port: func() int32 {
+				if port < 0 || port > 65535 {
+					panic(fmt.Errorf("invalid port value: %d", port))
+				}
+				return int32(port)
+			}(),
 			ActorName:           spawnRequest.Name,
 			ActorType:           spawnRequest.Kind,
 			IsSingleton:         spawnRequest.Singleton,

--- a/client/node.go
+++ b/client/node.go
@@ -170,7 +170,11 @@ func (n *Node) Free() {
 func (n *Node) HostAndPort() (string, int) {
 	n.mutex.Lock()
 	host, p, _ := net.SplitHostPort(n.address)
-	port, _ := strconv.Atoi(p)
+	parsedPort, err := strconv.ParseInt(p, 10, 32)
+	if err != nil || parsedPort < 0 || parsedPort > 65535 {
+		panic(fmt.Errorf("invalid port value: %s", p))
+	}
+	port := int(parsedPort)
 	n.mutex.Unlock()
 	return host, port
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Tochemey/goakt/security/code-scanning/12](https://github.com/Tochemey/goakt/security/code-scanning/12)

To address the issue, we will replace the use of `strconv.Atoi` with `strconv.ParseInt` and specify a bit size of 32 to ensure safe parsing and conversion. Additionally, we will add explicit bounds checks to verify that the parsed value falls within the valid range for `int32` before performing the conversion. This ensures that the code is robust against malformed or malicious input.

Changes will be made in:
1. `client/node.go` to validate the `port` value after parsing.
2. `actor/remoting.go` to ensure safe conversion of `port` to `int32`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
