### PR TITLE
fix: pid.Logger() should use RLock instead of Lock

### DIFF
--- a/actor/pid.go
+++ b/actor/pid.go
@@ -1287,9 +1287,9 @@ func (pid *PID) UnWatch(cid *PID) {
 
 // Logger returns the logger sets when creating the PID
 func (pid *PID) Logger() log.Logger {
-	pid.fieldsLocker.Lock()
+	pid.fieldsLocker.RLock()
 	logger := pid.logger
-	pid.fieldsLocker.Unlock()
+	pid.fieldsLocker.RUnlock()
 	return logger
 }
 


### PR DESCRIPTION
https://github.com/Tochemey/goakt/blob/0180b24d60d5942657b5ec18d5c3bfc26d33663c/actor/pid.go#L376-L380

`pid.Stop` acquires a read lock (`RLock`) on `fieldsLocker`. This lock is held until the actor has fully stopped. Consequently, calling `pid.Logger()` during actor shutdown will result in a deadlock.