### PR TITLE
fix: should suspend pid before notify parent

### DIFF
--- a/actor/pid.go
+++ b/actor/pid.go
@@ -1777,11 +1777,11 @@ func (pid *PID) notifyParent(signal *supervisionSignal) {
 			directive,
 			pid.Name())
 
-		// notify parent about the failure
-		_ = pid.Tell(context.Background(), parent, msg)
 		// suspend the actor until the parent take an action
 		// based upon the supervisory strategy and directive
 		pid.suspend(msg.GetErrorMessage())
+		// notify parent about the failure
+		_ = pid.Tell(context.Background(), parent, msg)
 		return
 	}
 


### PR DESCRIPTION
If `suspend` is placed after `Tell`, the parent might process the `PanicSignal` before invoking `suspend`. In this case, if the child is `Stop`ped within the `PanicSignal`, and `suspend` is executed afterward, it will cause `Stop` to send a unit into `supervisionStopSignal` (with a buffer of 1). However, `notifyParent` is located in `startSupervision`, and at this point, no other goroutine is processing `supervisionStopSignal`. As a result, when `suspend` attempts to send a unit into `supervisionStopSignal` again, a deadlock occurs.