### PR TITLE
feat: :sparkles: add role-base feature to cluster singleton

### DIFF
--- a/actor/cluster_singleton_option.go
+++ b/actor/cluster_singleton_option.go
@@ -1,0 +1,77 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2025  Arsene Tochemey Gandote
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package actor
+
+import "github.com/tochemey/goakt/v3/internal/pointer"
+
+// clusterSingletonConfig holds configuration options for cluster singleton actors.
+type clusterSingletonConfig struct {
+	// role defines the role required for the node to spawn the singleton actor.
+	role *string
+}
+
+// newClusterSingletonConfig creates a new cluster singleton configuration.
+func newClusterSingletonConfig(opts ...ClusterSingletonOption) *clusterSingletonConfig {
+	csc := &clusterSingletonConfig{}
+	for _, opt := range opts {
+		opt(csc)
+	}
+	return csc
+}
+
+// Role returns the role required for the node to spawn the singleton actor.
+func (x clusterSingletonConfig) Role() *string {
+	return x.role
+}
+
+// ClusterSingletonOption defines a function type for configuring cluster singleton actors.
+type ClusterSingletonOption func(*clusterSingletonConfig)
+
+// WithSingletonRole pins the singleton to cluster members that advertise the specified role.
+//
+// When a role is provided, the actor system picks the oldest node in the cluster that reports
+// the role and spawns (or relocates) the singleton there. Nodes without the role will never
+// host the singleton; when no matching members exist, `SpawnSingleton` returns an error.
+//
+// Passing the empty string is a no-op and leaves the singleton eligible for placement on the
+// overall oldest cluster member.
+//
+// Example:
+//
+//	if err := system.SpawnSingleton(
+//		ctx,
+//		"scheduler",
+//		NewSchedulerActor(),
+//		WithSingletonRole("control-plane"),
+//	); err != nil {
+//		return err
+//	}
+func WithSingletonRole(role string) ClusterSingletonOption {
+	return func(c *clusterSingletonConfig) {
+		if role != "" {
+			c.role = pointer.To(role)
+		}
+	}
+}

--- a/actor/cluster_singleton_option_test.go
+++ b/actor/cluster_singleton_option_test.go
@@ -1,0 +1,41 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2025  Arsene Tochemey Gandote
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package actor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClusterSingletonOption(t *testing.T) {
+	cfg := newClusterSingletonConfig()
+	require.Nil(t, cfg.Role())
+
+	role := "payments"
+	WithSingletonRole(role)(cfg)
+	require.NotNil(t, cfg.Role())
+	require.Equal(t, role, *cfg.Role())
+}

--- a/actor/defaults.go
+++ b/actor/defaults.go
@@ -53,6 +53,8 @@ const (
 	DefaultClusterStateSyncInterval = time.Minute
 	// DefaultGrainRequestTimeout defines the default grain request timeout
 	DefaultGrainRequestTimeout = 5 * time.Second
+
+	kindRoleSeparator = "::"
 )
 
 var (

--- a/actor/fixtures_test.go
+++ b/actor/fixtures_test.go
@@ -1412,6 +1412,30 @@ func MockClusterPeer(t *testing.T, load uint64, metricErr error, opts ...connect
 	}
 }
 
+func MockSingletonClusterReadyActorSystem(t *testing.T) *actorSystem {
+	t.Helper()
+	ports := dynaport.Get(3)
+
+	sys, err := NewActorSystem("spawn-test", WithLogger(log.DiscardLogger))
+	require.NoError(t, err)
+
+	clusterNode := &discovery.Node{
+		Name:          "spawn-test-node",
+		Host:          "127.0.0.1",
+		DiscoveryPort: ports[0],
+		PeersPort:     ports[1],
+		RemotingPort:  ports[2],
+	}
+
+	actorSys := sys.(*actorSystem)
+	actorSys.started.Store(true)
+	actorSys.clusterEnabled.Store(true)
+	actorSys.remotingEnabled.Store(true)
+	actorSys.clusterNode = clusterNode
+
+	return actorSys
+}
+
 // //////////////////////////////////////// CLUSTER PROVIDERS MOCKS //////////////////////////////////////
 type providerFactory func(t *testing.T, host string, discoveryPort int) discovery.Provider
 

--- a/actor/pid_option.go
+++ b/actor/pid_option.go
@@ -30,6 +30,7 @@ import (
 	"github.com/tochemey/goakt/v3/extension"
 	"github.com/tochemey/goakt/v3/internal/collection"
 	"github.com/tochemey/goakt/v3/internal/eventstream"
+	"github.com/tochemey/goakt/v3/internal/pointer"
 	"github.com/tochemey/goakt/v3/log"
 	"github.com/tochemey/goakt/v3/passivation"
 	"github.com/tochemey/goakt/v3/remote"
@@ -138,5 +139,14 @@ func withPassivationStrategy(strategy passivation.Strategy) pidOption {
 func asSystemActor() pidOption {
 	return func(pid *PID) {
 		pid.isSystem.Store(true)
+	}
+}
+
+// withRole sets the role the actor belongs to
+func withRole(role string) pidOption {
+	return func(pid *PID) {
+		if role != "" {
+			pid.role = pointer.To(role)
+		}
 	}
 }

--- a/actor/pid_option_test.go
+++ b/actor/pid_option_test.go
@@ -136,3 +136,12 @@ func TestWithDependencies(t *testing.T) {
 	actual := pid.Dependency("id")
 	require.True(t, reflect.DeepEqual(actual, dependency))
 }
+
+func TestWithRole(t *testing.T) {
+	pid := &PID{}
+	option := withRole("payments")
+	option(pid)
+	role := pid.Role()
+	require.NotNil(t, role)
+	assert.Equal(t, "payments", *role)
+}

--- a/actor/relocator.go
+++ b/actor/relocator.go
@@ -175,6 +175,7 @@ func (r *relocator) spawnRemoteActor(ctx context.Context, actor *internalpb.Acto
 		Dependencies:        dependencies,
 		PassivationStrategy: codec.DecodePassivationStrategy(actor.GetPassivationStrategy()),
 		EnableStashing:      actor.GetEnableStash(),
+		Role:                actor.Role,
 	}
 
 	if err := r.remoting.RemoteSpawn(ctx, remoteHost, remotingPort, spawnRequest); err != nil {
@@ -310,7 +311,7 @@ func (r *relocator) recreateLocally(ctx context.Context, props *internalpb.Actor
 
 	if enforceSingleton && props.GetIsSingleton() {
 		// spawn the singleton actor
-		return r.pid.ActorSystem().SpawnSingleton(ctx, props.GetAddress().GetName(), actor)
+		return r.pid.ActorSystem().SpawnSingleton(ctx, props.GetAddress().GetName(), actor, WithSingletonRole(props.GetRole()))
 	}
 
 	if !props.GetRelocatable() {
@@ -323,6 +324,10 @@ func (r *relocator) recreateLocally(ctx context.Context, props *internalpb.Actor
 
 	if props.GetEnableStash() {
 		spawnOpts = append(spawnOpts, WithStashing())
+	}
+
+	if props.GetRole() != "" {
+		spawnOpts = append(spawnOpts, WithRole(props.GetRole()))
 	}
 
 	if len(props.GetDependencies()) > 0 {

--- a/actor/spawn_test.go
+++ b/actor/spawn_test.go
@@ -237,11 +237,9 @@ func TestSpawn(t *testing.T) {
 
 		// let us sleep for some time to make the actor idle
 		wg := sync.WaitGroup{}
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			pause.For(receivingDelay)
-			wg.Done()
-		}()
+		})
 		// block until timer is up
 		wg.Wait()
 		// let us send a message to the actor
@@ -267,11 +265,9 @@ func TestSpawn(t *testing.T) {
 
 		// let us sleep for some time to make the actor idle
 		wg := sync.WaitGroup{}
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			pause.For(receivingDelay)
-			wg.Done()
-		}()
+		})
 		// block until timer is up
 		wg.Wait()
 		// let us send a message to the actor

--- a/internal/cluster/peer.go
+++ b/internal/cluster/peer.go
@@ -47,6 +47,8 @@ type Peer struct {
 	RemotingPort int
 	// Roles represents the peer roles
 	Roles []string
+	// CreatedAt represents the time in nanoseconds the peer was created
+	CreatedAt int64
 }
 
 // PeerAddress returns address the node's peers will use to connect to

--- a/internal/internalpb/actor.pb.go
+++ b/internal/internalpb/actor.pb.go
@@ -38,7 +38,9 @@ type Actor struct {
 	// Specifies the dependencies
 	Dependencies []*Dependency `protobuf:"bytes,6,rep,name=dependencies,proto3" json:"dependencies,omitempty"`
 	// States whether the actor will require a stash buffer
-	EnableStash   bool `protobuf:"varint,7,opt,name=enable_stash,json=enableStash,proto3" json:"enable_stash,omitempty"`
+	EnableStash bool `protobuf:"varint,7,opt,name=enable_stash,json=enableStash,proto3" json:"enable_stash,omitempty"`
+	// Specifies the role the actor belongs to
+	Role          *string `protobuf:"bytes,8,opt,name=role,proto3,oneof" json:"role,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -122,12 +124,19 @@ func (x *Actor) GetEnableStash() bool {
 	return false
 }
 
+func (x *Actor) GetRole() string {
+	if x != nil && x.Role != nil {
+		return *x.Role
+	}
+	return ""
+}
+
 var File_internal_actor_proto protoreflect.FileDescriptor
 
 const file_internal_actor_proto_rawDesc = "" +
 	"\n" +
 	"\x14internal/actor.proto\x12\n" +
-	"internalpb\x1a\x11goakt/goakt.proto\x1a\x19internal/dependency.proto\x1a\x1ainternal/passivation.proto\"\xbf\x02\n" +
+	"internalpb\x1a\x11goakt/goakt.proto\x1a\x19internal/dependency.proto\x1a\x1ainternal/passivation.proto\"\xe1\x02\n" +
 	"\x05Actor\x12*\n" +
 	"\aaddress\x18\x01 \x01(\v2\x10.goaktpb.AddressR\aaddress\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12!\n" +
@@ -135,7 +144,9 @@ const file_internal_actor_proto_rawDesc = "" +
 	"\vrelocatable\x18\x04 \x01(\bR\vrelocatable\x12R\n" +
 	"\x14passivation_strategy\x18\x05 \x01(\v2\x1f.internalpb.PassivationStrategyR\x13passivationStrategy\x12:\n" +
 	"\fdependencies\x18\x06 \x03(\v2\x16.internalpb.DependencyR\fdependencies\x12!\n" +
-	"\fenable_stash\x18\a \x01(\bR\venableStashB\xa3\x01\n" +
+	"\fenable_stash\x18\a \x01(\bR\venableStash\x12\x17\n" +
+	"\x04role\x18\b \x01(\tH\x00R\x04role\x88\x01\x01B\a\n" +
+	"\x05_roleB\xa3\x01\n" +
 	"\x0ecom.internalpbB\n" +
 	"ActorProtoH\x02P\x01Z;github.com/tochemey/goakt/v3/internal/internalpb;internalpb\xa2\x02\x03IXX\xaa\x02\n" +
 	"Internalpb\xca\x02\n" +
@@ -179,6 +190,7 @@ func file_internal_actor_proto_init() {
 	}
 	file_internal_dependency_proto_init()
 	file_internal_passivation_proto_init()
+	file_internal_actor_proto_msgTypes[0].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/internal/internalpb/remoting.pb.go
+++ b/internal/internalpb/remoting.pb.go
@@ -599,7 +599,9 @@ type RemoteSpawnRequest struct {
 	// Specifies the dependencies
 	Dependencies []*Dependency `protobuf:"bytes,8,rep,name=dependencies,proto3" json:"dependencies,omitempty"`
 	// States whether the actor will require a stash buffer
-	EnableStash   bool `protobuf:"varint,9,opt,name=enable_stash,json=enableStash,proto3" json:"enable_stash,omitempty"`
+	EnableStash bool `protobuf:"varint,9,opt,name=enable_stash,json=enableStash,proto3" json:"enable_stash,omitempty"`
+	// Specifies the role the actor belongs to
+	Role          *string `protobuf:"bytes,10,opt,name=role,proto3,oneof" json:"role,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -695,6 +697,13 @@ func (x *RemoteSpawnRequest) GetEnableStash() bool {
 		return x.EnableStash
 	}
 	return false
+}
+
+func (x *RemoteSpawnRequest) GetRole() string {
+	if x != nil && x.Role != nil {
+		return *x.Role
+	}
+	return ""
 }
 
 type RemoteSpawnResponse struct {
@@ -1137,7 +1146,7 @@ const file_internal_remoting_proto_rawDesc = "" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
 	"\x04port\x18\x02 \x01(\x05R\x04port\x12\x12\n" +
 	"\x04name\x18\x03 \x01(\tR\x04name\"\x14\n" +
-	"\x12RemoteStopResponse\"\xf2\x02\n" +
+	"\x12RemoteStopResponse\"\x94\x03\n" +
 	"\x12RemoteSpawnRequest\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
 	"\x04port\x18\x02 \x01(\x05R\x04port\x12\x1d\n" +
@@ -1149,7 +1158,10 @@ const file_internal_remoting_proto_rawDesc = "" +
 	"\vrelocatable\x18\x06 \x01(\bR\vrelocatable\x12R\n" +
 	"\x14passivation_strategy\x18\a \x01(\v2\x1f.internalpb.PassivationStrategyR\x13passivationStrategy\x12:\n" +
 	"\fdependencies\x18\b \x03(\v2\x16.internalpb.DependencyR\fdependencies\x12!\n" +
-	"\fenable_stash\x18\t \x01(\bR\venableStash\"\x15\n" +
+	"\fenable_stash\x18\t \x01(\bR\venableStash\x12\x17\n" +
+	"\x04role\x18\n" +
+	" \x01(\tH\x00R\x04role\x88\x01\x01B\a\n" +
+	"\x05_role\"\x15\n" +
 	"\x13RemoteSpawnResponse\"T\n" +
 	"\x16RemoteReinstateRequest\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
@@ -1282,6 +1294,7 @@ func file_internal_remoting_proto_init() {
 	file_internal_dependency_proto_init()
 	file_internal_grain_proto_init()
 	file_internal_passivation_proto_init()
+	file_internal_remoting_proto_msgTypes[11].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/mocks/cluster/cluster.go
+++ b/mocks/cluster/cluster.go
@@ -723,6 +723,64 @@ func (_c *Cluster_LookupKind_Call) RunAndReturn(run func(context.Context, string
 	return _c
 }
 
+// Members provides a mock function with given fields: ctx
+func (_m *Cluster) Members(ctx context.Context) ([]*internalcluster.Peer, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Members")
+	}
+
+	var r0 []*internalcluster.Peer
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) ([]*internalcluster.Peer, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) []*internalcluster.Peer); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*internalcluster.Peer)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Cluster_Members_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Members'
+type Cluster_Members_Call struct {
+	*mock.Call
+}
+
+// Members is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Cluster_Expecter) Members(ctx interface{}) *Cluster_Members_Call {
+	return &Cluster_Members_Call{Call: _e.mock.On("Members", ctx)}
+}
+
+func (_c *Cluster_Members_Call) Run(run func(ctx context.Context)) *Cluster_Members_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *Cluster_Members_Call) Return(_a0 []*internalcluster.Peer, _a1 error) *Cluster_Members_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Cluster_Members_Call) RunAndReturn(run func(context.Context) ([]*internalcluster.Peer, error)) *Cluster_Members_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Peers provides a mock function with given fields: ctx
 func (_m *Cluster) Peers(ctx context.Context) ([]*internalcluster.Peer, error) {
 	ret := _m.Called(ctx)

--- a/protos/internal/actor.proto
+++ b/protos/internal/actor.proto
@@ -22,6 +22,8 @@ message Actor {
   PassivationStrategy passivation_strategy = 5;
   // Specifies the dependencies
   repeated internalpb.Dependency dependencies = 6;
-  //  States whether the actor will require a stash buffer
+  // States whether the actor will require a stash buffer
   bool enable_stash = 7;
+  // Specifies the role the actor belongs to
+  optional string role = 8;
 }

--- a/protos/internal/remoting.proto
+++ b/protos/internal/remoting.proto
@@ -132,6 +132,8 @@ message RemoteSpawnRequest {
   repeated internalpb.Dependency dependencies = 8;
   //  States whether the actor will require a stash buffer
   bool enable_stash = 9;
+  // Specifies the role the actor belongs to
+  optional string role = 10;
 }
 
 message RemoteSpawnResponse {}

--- a/remote/remoting.go
+++ b/remote/remoting.go
@@ -557,6 +557,7 @@ func (r *remoting) RemoteSpawn(ctx context.Context, host string, port int, spawn
 			PassivationStrategy: codec.EncodePassivationStrategy(spawnRequest.PassivationStrategy),
 			Dependencies:        dependencies,
 			EnableStash:         spawnRequest.EnableStashing,
+			Role:                spawnRequest.Role,
 		},
 	)
 

--- a/remote/spawn_request.go
+++ b/remote/spawn_request.go
@@ -93,6 +93,16 @@ type SpawnRequest struct {
 	// When used correctly, the stash buffer is a powerful tool for managing transient states
 	// and preserving actor responsiveness while maintaining orderly message handling.
 	EnableStashing bool
+
+	// Role narrows placement to cluster members that advertise the given role.
+	//
+	// In a clustered deployment, GoAkt uses placement roles to constrain where actors may be
+	// started or relocated. When `Role` is non-nil the actor will only be considered for nodes
+	// that list the same role; clearing the field makes the actor eligible on any node.
+	//
+	// ⚠️ Note: This setting has effect only for `SpawnOn` and `SpawnSingleton` requests. Local-only
+	// spawns ignore it.
+	Role *string
 }
 
 // _ ensures that SpawnRequest implements the validation.Validator interface at compile time.


### PR DESCRIPTION
Adds role-aware placement for cluster singletons. When a role is specified, the singleton is spawned (or relocated) on the oldest member that reports that role. Nodes without the role will never host the singleton. If no matching members are available, SpawnSingleton fails with an error. If no role is provided, the existing behavior is unchanged.

## Details
* With a role
   * Placement target: oldest up node that has the role.
   * Relocation: follows the oldest eligible node when membership changes.
   * Exclusion: nodes lacking the role are never candidates.
   * Failure mode: if the cluster has zero members with the role, SpawnSingleton returns an error immediately.
* Without a role: Behavior remains identical to current implementation (backward-compatible).

## Rationale

- Enables pinning critical singletons to a constrained pool (e.g., nodes with SSDs, GPUs, or special configs).
- Predictable failover by always preferring the oldest eligible member.