### PR TITLE
fix: recreate shutdownSignal in Start to avoid grain activation/shutdown race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ l.Warn("passes the floor")
 
 A runnable sample lives in `playground/issue-1201`.
 
+#### Data race between actor-system shutdown and in-flight grain activation
+
+Under `-race`, stopping a clustered `ActorSystem` while a grain was being activated tripped the race detector ([#1205](https://github.com/Tochemey/goakt/issues/1205)). `reset()` (reached from `Stop()`) recreated the `shutdownSignal` channel during teardown, while a concurrent `putGrainOnCluster()` (reached from `GrainIdentity`/`TellGrain`/`AskGrain`) read that same field in its publish `select`, with no synchronization between the two paths. The node-local grain fast path widened the window where activation overlaps shutdown, which is why it surfaced after v4.2.8.
+
+`shutdownSignal` is now recreated once at the start of `Start()`, the only point where no cluster producer or replicate drainer is alive, instead of during `reset()`. Teardown leaves the channel closed, so any producer racing shutdown only ever reads a stable closed channel (its `select` returns at once and the publish is skipped, exactly as intended). The fix adds no locks, atomics, or hot-path allocations, and covers both `putGrainOnCluster` and the structurally identical `putActorOnCluster`.
+
 ## v4.2.8 - 2026-10-01
 
 ### ✨ New Additions

--- a/actor/actor_system.go
+++ b/actor/actor_system.go
@@ -1109,6 +1109,14 @@ func (x *actorSystem) Start(ctx context.Context) error {
 	x.logger.Infof("starting actor system=%s os=%s arch=%s", x.name, runtime.GOOS, runtime.GOARCH)
 	x.starting.Store(true)
 
+	// (Re)create shutdownSignal here, the only point where no cluster
+	// producer or replicate drainer is alive yet. Recreating it during
+	// teardown (in reset()) would race the concurrent reads in
+	// putActorOnCluster / putGrainOnCluster. A fresh channel per start
+	// lets the next shutdown close it exactly once without double-closing
+	// the one a prior teardown already closed.
+	x.shutdownSignal = make(chan types.Unit)
+
 	x.scheduler = newScheduler(x.logger, x.shutdownTimeout, x)
 
 	x.dispatcher.start()
@@ -2358,10 +2366,8 @@ func (x *actorSystem) startCluster(ctx context.Context) error {
 	x.eventsQueue = x.cluster.Events()
 	x.rebalancingQueue = make(chan *internalpb.PeerState, 1)
 	go x.clusterEventsLoop()
-	// Track the replicate drainers so shutdown can wait for them to
-	// exit before reset() reassigns shutdownSignal. Without this, the
-	// drainer's initial read of x.shutdownSignal would have no
-	// happens-before relation to reset()'s later write.
+	// Track the replicate drainers so shutdown can wait for them to drain
+	// the cluster queues before reset() clears the rest of the state.
 	x.drainers.Add(2)
 	go x.replicateActors()
 	go x.replicateGrains()
@@ -2528,9 +2534,9 @@ func (x *actorSystem) startupCleanup(ctx context.Context) {
 	}
 
 	x.dispatcher.signalStop()
-	// Wait for replicate drainers before reset reassigns shutdownSignal.
-	// If cluster setup never got as far as spawning them, drainers' count
-	// is zero and Wait returns immediately.
+	// Wait for the replicate drainers to drain the cluster queues before
+	// reset() clears state. If cluster setup never got as far as spawning
+	// them, drainers' count is zero and Wait returns immediately.
 	x.drainers.Wait()
 	x.reset()
 }
@@ -2543,11 +2549,8 @@ func (x *actorSystem) reset() {
 	x.actors.reset()
 	x.grains.Reset()
 	x.shuttingDown.Store(false)
-	// Recreate shutdownSignal so a subsequent shutdown or startupCleanup
-	// can close it exactly once. Without this, restarting the system
-	// after a prior shutdown / startup failure would double-close the
-	// same channel on the next teardown.
-	x.shutdownSignal = make(chan types.Unit)
+	// shutdownSignal is intentionally left closed here. It is recreated in
+	// Start(), the only point where no producer/drainer can race the write.
 	x.clusterStore = nil
 	x.dataCenterController = nil
 	x.dataCenterLeaderTicker = nil
@@ -2570,10 +2573,10 @@ func (x *actorSystem) shutdown(ctx context.Context) (err error) {
 	}
 
 	defer func() {
-		// Wait for the replicate drainers to exit before reset()
-		// reassigns shutdownSignal. Drainers already observed the
-		// close above and will return shortly after draining any
-		// buffered items, so this does not add meaningful latency.
+		// Wait for the replicate drainers to exit before reset() clears
+		// state. Drainers already observed the close above and will return
+		// shortly after draining any buffered items, so this does not add
+		// meaningful latency.
 		x.drainers.Wait()
 		x.reset()
 		// Signal dispatcher shutdown after all actors are torn down and

--- a/actor/actor_system.go
+++ b/actor/actor_system.go
@@ -909,9 +909,8 @@ type actorSystem struct {
 	// Guarded by the shuttingDown CAS so close runs exactly once.
 	shutdownSignal chan types.Unit
 	// drainers tracks the replicateActors / replicateGrains goroutines.
-	// shutdown waits on it before reset() reassigns shutdownSignal, so
-	// the drainer's initial read of the field happens-before any later
-	// reassignment for a restart cycle.
+	// shutdown waits on it so the drainers finish draining the cluster
+	// queues before reset() clears the rest of the system state.
 	drainers         sync.WaitGroup
 	grainsQueue      chan *internalpb.Grain
 	grains           *xsync.Map[string, *grainPID]

--- a/actor/grain_engine_test.go
+++ b/actor/grain_engine_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/tochemey/goakt/v4/internal/remoteclient"
 	"github.com/tochemey/goakt/v4/log"
 	mockcluster "github.com/tochemey/goakt/v4/mocks/cluster"
+	mockdiscovery "github.com/tochemey/goakt/v4/mocks/discovery"
 	mockremote "github.com/tochemey/goakt/v4/mocks/remoteclient"
 	"github.com/tochemey/goakt/v4/remote"
 	"github.com/tochemey/goakt/v4/test/data/testpb"
@@ -1723,4 +1724,76 @@ func TestGrainContextPropagation(t *testing.T) {
 			return grain.Seen() == headerVal
 		}, 2*time.Second, 50*time.Millisecond)
 	})
+}
+
+// TestGrainActivationDuringShutdownNoRace reproduces issue https://github.com/Tochemey/goakt/issues/1205: a data race
+// between actorSystem shutdown (reset()) and an in-flight grain activation
+// reading shutdownSignal in putGrainOnCluster(). Several goroutines publish
+// grains to the cluster (the exact racing read) right up to and during Stop()
+// (which calls reset(), the racing write). Must be run under -race.
+func TestGrainActivationDuringShutdownNoRace(t *testing.T) {
+	ctx := context.TODO()
+	nodePorts := internalnet.Get(3)
+	gossipPort := nodePorts[0]
+	clusterPort := nodePorts[1]
+	remotingPort := nodePorts[2]
+	host := "127.0.0.1"
+
+	addrs := []string{net.JoinHostPort(host, strconv.Itoa(gossipPort))}
+
+	provider := new(mockdiscovery.Provider)
+	system, err := NewActorSystem(
+		"test",
+		WithLogger(log.DiscardLogger),
+		WithRemote(remote.NewConfig(host, remotingPort)),
+		WithCluster(
+			NewClusterConfig().
+				WithKinds(new(MockActor)).
+				WithGrains(new(MockGrain)).
+				WithPartitionCount(9).
+				WithReplicaCount(1).
+				WithPeersPort(clusterPort).
+				WithMinimumPeersQuorum(1).
+				WithDiscoveryPort(gossipPort).
+				WithDiscovery(provider)),
+	)
+	require.NoError(t, err)
+
+	provider.EXPECT().ID().Return("testDisco")
+	provider.EXPECT().Initialize().Return(nil)
+	provider.EXPECT().Register().Return(nil)
+	provider.EXPECT().Deregister().Return(nil)
+	provider.EXPECT().DiscoverPeers().Return(addrs, nil)
+	provider.EXPECT().Close().Return(nil)
+
+	require.NoError(t, system.Start(ctx))
+	pause.For(time.Second)
+
+	sys := system.(*actorSystem)
+
+	// Several publishers keep evaluating putGrainOnCluster's select (which
+	// reads x.shutdownSignal) so reads overlap reset()'s write during Stop.
+	// Each goroutine owns its grain/identity to avoid unrelated shared state.
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range 8 {
+		grain := NewMockGrain()
+		pid := newGrainPID(newGrainIdentity(grain, "race-grain-"+strconv.Itoa(i)), grain, sys, newGrainConfig())
+		wg.Go(func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = sys.putGrainOnCluster(pid)
+				}
+			}
+		})
+	}
+
+	require.NoError(t, system.Stop(ctx))
+	close(stop)
+	wg.Wait()
+
+	provider.AssertExpectations(t)
 }


### PR DESCRIPTION
closes #1205 