### PR TITLE
feat: spawn option for ephemeral high-churn actors (#1234)

### DIFF
--- a/actor/actor_system_test.go
+++ b/actor/actor_system_test.go
@@ -6693,6 +6693,38 @@ func TestPreShutdown(t *testing.T) {
 		require.NoError(t, err)
 		assert.Nil(t, peerState)
 	})
+
+	t.Run("excludes ephemeral actors from the peer state snapshot", func(t *testing.T) {
+		ctx := context.TODO()
+		clusterMock := mockscluster.NewCluster(t)
+		system := MockReplicationTestSystem(clusterMock)
+		system.relocationEnabled.Store(true)
+
+		require.NoError(t, system.spawnRootGuardian(ctx))
+		require.NoError(t, system.spawnSystemGuardian(ctx))
+		require.NoError(t, system.spawnUserGuardian(ctx))
+
+		clusterMock.EXPECT().ActorExists(mock.Anything, "durable").Return(false, nil).Once()
+		clusterMock.EXPECT().ActorExists(mock.Anything, "ephemeral").Return(false, nil).Once()
+
+		durablePID, err := system.Spawn(ctx, "durable", NewMockActor())
+		require.NoError(t, err)
+		require.True(t, durablePID.IsRelocatable())
+
+		ephemeralPID, err := system.Spawn(ctx, "ephemeral", NewMockActor(), WithEphemeral())
+		require.NoError(t, err)
+		require.False(t, ephemeralPID.IsRelocatable())
+
+		peerState, err := system.preShutdown()
+		require.NoError(t, err)
+		require.NotNil(t, peerState)
+
+		_, hasDurable := peerState.GetActors()[durablePID.ID()]
+		assert.True(t, hasDurable, "relocatable actor must be part of the peer state snapshot")
+
+		_, hasEphemeral := peerState.GetActors()[ephemeralPID.ID()]
+		assert.False(t, hasEphemeral, "ephemeral actor must be excluded from relocation bookkeeping")
+	})
 }
 
 func TestPersistPeerStateToPeers(t *testing.T) {

--- a/actor/ephemeral_bench_test.go
+++ b/actor/ephemeral_bench_test.go
@@ -1,0 +1,77 @@
+// MIT License
+//
+// Copyright (c) 2022-2026 GoAkt Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package actor
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/tochemey/goakt/v4/log"
+)
+
+// BenchmarkSpawnStopDefault spawns and stops one actor per iteration using the
+// framework defaults (relocatable, idle-based passivation bookkeeping). It is the
+// baseline against which BenchmarkSpawnStopEphemeral is compared for high-churn,
+// connection-shaped workloads (see WithEphemeral).
+func BenchmarkSpawnStopDefault(b *testing.B) {
+	benchmarkSpawnStop(b)
+}
+
+// BenchmarkSpawnStopEphemeral spawns and stops one actor per iteration using
+// WithEphemeral, the option recommended for connection-lifetime actors.
+func BenchmarkSpawnStopEphemeral(b *testing.B) {
+	benchmarkSpawnStop(b, WithEphemeral())
+}
+
+// benchmarkSpawnStop drives repeated spawn/stop cycles against a standalone
+// (non-clustered) actor system so the measured cost isolates per-actor bookkeeping
+// (passivation registration and relocation state) rather than cluster RPCs.
+func benchmarkSpawnStop(b *testing.B, opts ...SpawnOption) {
+	b.Helper()
+	ctx := context.TODO()
+
+	system, err := NewActorSystem("bench-spawn-stop", WithLogger(log.DiscardLogger))
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := system.Start(ctx); err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() {
+		_ = system.Stop(ctx)
+	})
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		name := "conn-" + strconv.Itoa(i)
+		pid, err := system.Spawn(ctx, name, NewMockActor(), opts...)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := pid.Shutdown(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/actor/relocator_test.go
+++ b/actor/relocator_test.go
@@ -1068,6 +1068,91 @@ func TestRelocationWithActorRelocationDisabled(t *testing.T) {
 	srv.Shutdown()
 }
 
+// TestRelocationWithEphemeralActor proves that an actor spawned with WithEphemeral,
+// the option recommended for connection-lifetime actors, is excluded from relocation
+// bookkeeping the same way an actor spawned with WithRelocationDisabled is: it never
+// reappears on a surviving peer once its host node leaves the cluster.
+func TestRelocationWithEphemeralActor(t *testing.T) {
+	// create a context
+	ctx := context.TODO()
+	// start the NATS server
+	srv := startNatsServer(t)
+
+	// create and start system cluster
+	node1, sd1 := testNATs(t, srv.Addr().String())
+	require.NotNil(t, node1)
+	require.NotNil(t, sd1)
+
+	// create and start system cluster
+	node2, sd2 := testNATs(t, srv.Addr().String())
+	require.NotNil(t, node2)
+	require.NotNil(t, sd2)
+
+	// create and start system cluster
+	node3, sd3 := testNATs(t, srv.Addr().String())
+	require.NotNil(t, node3)
+	require.NotNil(t, sd3)
+
+	for j := 1; j <= 4; j++ {
+		actorName := fmt.Sprintf("Node1-Actor-%d", j)
+		pid, err := node1.Spawn(ctx, actorName, NewMockActor())
+		require.NoError(t, err)
+		require.NotNil(t, pid)
+	}
+
+	pause.For(time.Second)
+
+	for j := 1; j <= 4; j++ {
+		actorName := fmt.Sprintf("Node2-Actor-%d", j)
+		pid, err := node2.Spawn(ctx, actorName, NewMockActor(), WithEphemeral())
+		require.NoError(t, err)
+		require.NotNil(t, pid)
+		require.False(t, pid.IsRelocatable())
+	}
+
+	pause.For(time.Second)
+
+	for j := 1; j <= 4; j++ {
+		actorName := fmt.Sprintf("Node3-Actor-%d", j)
+		pid, err := node3.Spawn(ctx, actorName, NewMockActor())
+		require.NoError(t, err)
+		require.NotNil(t, pid)
+	}
+
+	pause.For(time.Second)
+
+	// take down node2
+	require.NoError(t, node2.Stop(ctx))
+	require.NoError(t, sd2.Close())
+
+	// Allow time for the cluster to detect node2 leaving
+	pause.For(2 * time.Second)
+
+	// Verify the ephemeral actor is never relocated.
+	// We poll for a reasonable window to confirm the actor stays gone.
+	actorName := "Node2-Actor-1"
+	require.Eventually(t, func() bool {
+		exists, err := node1.ActorExists(ctx, actorName)
+		if err != nil {
+			return false
+		}
+		return !exists
+	}, 30*time.Second, time.Second, "ephemeral actor %s should not be relocated", actorName)
+
+	sender, err := node1.ActorOf(ctx, "Node1-Actor-1")
+	require.NoError(t, err)
+	require.NotNil(t, sender)
+
+	err = sender.SendAsync(ctx, actorName, new(testpb.TestSend))
+	require.Error(t, err)
+
+	assert.NoError(t, node1.Stop(ctx))
+	assert.NoError(t, node3.Stop(ctx))
+	assert.NoError(t, sd1.Close())
+	assert.NoError(t, sd3.Close())
+	srv.Shutdown()
+}
+
 func TestRelocationWithSystemRelocationDisabled(t *testing.T) {
 	// create a context
 	ctx := context.TODO()

--- a/actor/spawn_option.go
+++ b/actor/spawn_option.go
@@ -314,6 +314,34 @@ func WithRelocationDisabled() SpawnOption {
 	})
 }
 
+// WithEphemeral returns a SpawnOption bundling the settings recommended for
+// connection-lifetime actors: one actor per websocket/SSE/streaming client, spawned
+// and stopped at high rates and living exactly as long as the connection it represents.
+//
+// It combines:
+//   - Relocation disabled: a connection actor is useless on another node once its
+//     underlying socket has died with the node that hosted it, so it must never be
+//     recreated elsewhere during cluster rebalancing.
+//   - Long-lived passivation: the caller stops the actor explicitly when the
+//     connection closes, so registering it with the passivation manager's idle-timer
+//     bookkeeping would only add overhead that is never exercised.
+//
+// This is equivalent to combining WithRelocationDisabled and
+// WithPassivationStrategy(passivation.NewLongLivedStrategy()), expressed as a single
+// self-describing option for the connection-actor pattern.
+//
+// WithEphemeral does not stop the actor for you: call Shutdown (or PID.Shutdown)
+// when the underlying connection closes.
+//
+// Returns:
+//   - SpawnOption that disables relocation and idle-based passivation bookkeeping for the actor.
+func WithEphemeral() SpawnOption {
+	return spawnOption(func(config *spawnConfig) {
+		config.relocatable = false
+		config.passivationStrategy = passivation.NewLongLivedStrategy()
+	})
+}
+
 // WithDependencies returns a SpawnOption that injects the given dependencies into
 // the actor during its initialization.
 //

--- a/actor/spawn_option_test.go
+++ b/actor/spawn_option_test.go
@@ -117,6 +117,13 @@ func TestSpawnOption(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorIs(t, err, errors.ErrInvalidTCPAddress)
 	})
+	t.Run("spawn option with ephemeral", func(t *testing.T) {
+		config := &spawnConfig{relocatable: true}
+		option := WithEphemeral()
+		option.Apply(config)
+		require.False(t, config.relocatable)
+		require.IsType(t, &passivation.LongLivedStrategy{}, config.passivationStrategy)
+	})
 }
 
 func TestNewSpawnConfig(t *testing.T) {

--- a/docs/actor/ephemeral-actors.mdx
+++ b/docs/actor/ephemeral-actors.mdx
@@ -1,0 +1,87 @@
+---
+title: Ephemeral Actors
+description: Spawn options for high-churn, connection-lifetime actors.
+sidebarTitle: "Ephemeral Actors"
+---
+
+An **ephemeral actor** is an actor whose lifetime is tied to something external and short-lived — most commonly a single websocket or SSE connection. One actor is spawned per connection and stopped the moment the connection closes. Under real traffic this means thousands of spawn/stop cycles per second across the cluster.
+
+These actors should **never** participate in cluster bookkeeping designed for long-lived actors:
+
+- **Relocation** — if the node hosting a connection actor crashes or leaves, the underlying socket is already gone. Recreating the actor on another node produces an actor with no connection to serve; it is pure waste.
+- **Idle-based passivation** — the actor's lifetime is already driven by an external event (the connection closing). Registering it with the passivation manager's timer bookkeeping adds a heap insert/remove on every spawn/stop for a timer that will never fire.
+
+`WithEphemeral` is a single, self-describing [`SpawnOption`](/actor/actor-system) that captures this intent instead of a recipe of unrelated options.
+
+## Usage
+
+```go
+pid, err := system.Spawn(ctx, connectionID, NewConnectionActor(conn),
+    actor.WithEphemeral())
+```
+
+`WithEphemeral` is equivalent to combining:
+
+```go
+actor.WithRelocationDisabled()
+actor.WithPassivationStrategy(passivation.NewLongLivedStrategy())
+```
+
+<Note>
+`WithEphemeral` does not stop the actor for you. You are expected to call `pid.Shutdown(ctx)` (or send a `Shutdown`/stop message) when the underlying connection closes — that is the whole point: the actor's lifetime is driven by the connection, not by an idle timer.
+</Note>
+
+<Warning>
+Ephemeral actors are still subject to [system eviction](/actor/passivation#system-eviction) if you configure `WithEvictionStrategy`. Eviction is a node-wide capacity limit and is independent of both relocation and per-actor passivation.
+</Warning>
+
+## The connection-actor pattern
+
+A common gateway shape looks like this:
+
+1. A client opens a websocket or SSE connection to any node in the cluster.
+2. The node spawns one actor per connection with `WithEphemeral`, using the connection ID as the actor name so it can be addressed by other nodes.
+3. Inbound messages from the socket are `Tell`'d to the actor; outbound messages are written directly to the socket from within the actor (or from a `Receive` handler holding the connection).
+4. When the socket closes (client disconnect, read/write error, or server shutdown), the caller stops the actor immediately: `pid.Shutdown(ctx)`.
+5. If the node crashes or leaves the cluster, the connection is already dead — the actor is correctly **not** relocated, and the client is expected to reconnect (to any node) and get a fresh actor.
+
+```go
+type ConnectionActor struct {
+    conn net.Conn
+}
+
+func (a *ConnectionActor) PreStart(*actor.Context) error { return nil }
+
+func (a *ConnectionActor) Receive(ctx *actor.ReceiveContext) {
+    switch msg := ctx.Message().(type) {
+    case *OutboundFrame:
+        _, _ = a.conn.Write(msg.GetPayload())
+    }
+}
+
+func (a *ConnectionActor) PostStop(*actor.Context) error {
+    return a.conn.Close()
+}
+
+// on connection accept
+pid, err := system.Spawn(ctx, connectionID, &ConnectionActor{conn: conn},
+    actor.WithEphemeral())
+
+// on connection close (read loop exit, client disconnect, etc.)
+_ = pid.Shutdown(ctx)
+```
+
+## Why not just use existing options
+
+`WithRelocationDisabled` and `WithPassivationStrategy(passivation.NewLongLivedStrategy())` already exist and can be combined manually. `WithEphemeral` exists because:
+
+- The combination is easy to get wrong or forget one half of (e.g. disabling relocation but leaving the default idle-based passivation registered).
+- The name documents *intent* — "this actor represents a connection and is explicitly managed" — rather than a list of unrelated knobs.
+
+If your actor is long-lived but must not relocate (e.g. it owns node-local state), use `WithRelocationDisabled` directly; `WithEphemeral` is specifically for the high-churn, externally-driven-lifetime case.
+
+## See also
+
+- [Relocation](/actor/relocation) — how relocation works and `WithRelocationDisabled`
+- [Passivation](/actor/passivation) — passivation strategies and system eviction
+- [Actor System](/actor/actor-system) — `Spawn`, `SpawnOn`, and `SpawnOption`


### PR DESCRIPTION
Closes #1234

Adds `WithEphemeral()`, a self-describing spawn option for connection-lifetime actors (one actor per websocket/SSE client, spawned and stopped at high rates):

- Relocation disabled: a connection actor is useless on another node once its socket died with the node that hosted it.
- Long-lived passivation strategy: the caller stops the actor explicitly on disconnect, so idle-timer bookkeeping is skipped.

Equivalent to combining `WithRelocationDisabled` and `WithPassivationStrategy(passivation.NewLongLivedStrategy())`, expressed as one option for the connection-actor pattern.

Testing: unit tests proving an ephemeral actor is excluded from relocation bookkeeping, plus a spawn/stop churn benchmark. `make lint` and the affected package suites pass with `-race`.

Docs: new page describing the ephemeral connection-actor pattern.
