### PR TITLE
feat: non-actor subscriber bridge for PubSub (#1237)

### DIFF
--- a/actor/actor_system.go
+++ b/actor/actor_system.go
@@ -465,6 +465,38 @@ type ActorSystem interface {
 	//
 	// Returns the actor reference for the topic actor.
 	TopicActor() *PID
+	// SubscribeTopic registers a plain callback as a subscriber of the given topic, without
+	// requiring the caller to define or spawn an Actor. This is the non-actor counterpart of
+	// sending a Subscribe message to TopicActor(); it is meant for gateway-style integrations
+	// (e.g. a websocket/SSE handler) that only need to forward published messages somewhere.
+	//
+	// Internally, a bridge actor is spawned to subscribe to the topic like any other actor
+	// subscriber would, so delivery ordering, at-least-once semantics, cross-node dissemination,
+	// and the existing deduplication/retention behavior are all unchanged. handler is invoked
+	// once per delivered message; a panic inside handler is recovered and logged and never
+	// terminates the subscription.
+	//
+	// Requirements:
+	//   - PubSub mode must be enabled, either via WithPubSub() or because cluster mode is enabled.
+	//     Otherwise ErrPubSubDisabled is returned.
+	//
+	// Parameters:
+	//   - topic: the topic name to subscribe to.
+	//   - handler: invoked with each message delivered to topic. It runs on the bridge actor's
+	//     goroutine; keep it fast or hand off blocking work to avoid delaying other deliveries.
+	//
+	// Returns:
+	//   - Subscription: call Unsubscribe or Close on it to stop delivery and release the bridge actor.
+	//   - error: ErrActorSystemNotStarted if the system is not running, ErrPubSubDisabled if pub/sub
+	//     is not enabled, ErrSubscribeHandlerRequired if handler is nil, or a spawn error otherwise.
+	//
+	// Usage:
+	//
+	//	sub, err := system.SubscribeTopic("orders", func(ctx context.Context, msg proto.Message) {
+	//	    // forward msg to a websocket connection, log it, etc.
+	//	})
+	//	defer sub.Close()
+	SubscribeTopic(topic string, handler func(ctx context.Context, message proto.Message)) (Subscription, error)
 	// Replicator returns the PID of the local CRDT Replicator system actor.
 	// Returns nil if CRDT replication is not enabled via ClusterConfig.WithCRDT.
 	Replicator() *PID

--- a/actor/pubsub_bridge.go
+++ b/actor/pubsub_bridge.go
@@ -162,7 +162,16 @@ func (x *actorSystem) SubscribeTopic(topic string, handler func(ctx context.Cont
 	}
 
 	name := fmt.Sprintf("%s-%s", pubsubBridgeNamePrefix, uuid.NewString())
-	pid, err := x.Spawn(context.Background(), name,
+
+	// The bridge is spawned via configPID directly (the same path topicActor and replicator
+	// use) rather than the public Spawn, and deliberately skips putActorOnCluster: it is a
+	// purely local construct that topicActor only ever addresses by its in-memory *PID, so it
+	// never needs cluster-wide resolution. Routing it through Spawn would register it in the
+	// cluster's actor directory on creation but, because asSystem() marks it as a system actor,
+	// the death watch's cluster cleanup on termination is skipped for system actors - leaking
+	// one cluster-directory entry per SubscribeTopic/Unsubscribe cycle for the lifetime of the
+	// cluster, which matters for exactly the churn-heavy gateway workloads this API targets.
+	pid, err := x.configPID(context.Background(), name,
 		newPubSubBridgeActor(topic, topicActorPID, handler),
 		asSystem(),
 		WithLongLived(),
@@ -177,6 +186,11 @@ func (x *actorSystem) SubscribeTopic(topic string, handler func(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+
+	if err := x.actors.addNode(x.systemGuardian, pid); err != nil {
+		return nil, err
+	}
+	x.actors.addWatcher(pid, x.deathWatch)
 
 	return &pubsubBridgeSubscription{topic: topic, pid: pid}, nil
 }

--- a/actor/pubsub_bridge.go
+++ b/actor/pubsub_bridge.go
@@ -1,0 +1,182 @@
+// MIT License
+//
+// Copyright (c) 2022-2026 GoAkt Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package actor
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/proto"
+
+	gerrors "github.com/tochemey/goakt/v4/errors"
+	"github.com/tochemey/goakt/v4/log"
+	"github.com/tochemey/goakt/v4/supervisor"
+)
+
+// pubsubBridgeNamePrefix names the internal actor spawned per SubscribeTopic call.
+// It intentionally does not start with the reserved "GoAkt" prefix (see reservedNamesPrefix)
+// so the bridge actor can be shut down like any ordinary actor from Subscription.Unsubscribe.
+const pubsubBridgeNamePrefix = "goaktPubSubBridge"
+
+// Subscription represents a non-actor subscription to a pub/sub topic created via
+// ActorSystem.SubscribeTopic. It wraps an internally managed bridge actor that forwards
+// messages published to the topic to the handler supplied at subscription time.
+type Subscription interface {
+	// Topic returns the topic this subscription is bound to.
+	Topic() string
+	// Unsubscribe stops the subscription: no further messages are delivered to the handler
+	// and the underlying bridge actor is shut down. It is safe to call more than once; only
+	// the first call has any effect.
+	Unsubscribe() error
+	// Close is an alias for Unsubscribe, provided so a Subscription can be used with defer
+	// alongside other closer-style resources.
+	Close() error
+}
+
+// pubsubBridgeSubscription is the default Subscription implementation returned by
+// ActorSystem.SubscribeTopic.
+type pubsubBridgeSubscription struct {
+	topic string
+	pid   *PID
+	once  sync.Once
+	err   error
+}
+
+// enforce compilation error
+var _ Subscription = (*pubsubBridgeSubscription)(nil)
+
+// Topic returns the topic this subscription is bound to.
+func (s *pubsubBridgeSubscription) Topic() string { return s.topic }
+
+// Unsubscribe implements Subscription.
+func (s *pubsubBridgeSubscription) Unsubscribe() error {
+	s.once.Do(func() {
+		s.err = s.pid.Shutdown(context.Background())
+	})
+	return s.err
+}
+
+// Close implements Subscription.
+func (s *pubsubBridgeSubscription) Close() error {
+	return s.Unsubscribe()
+}
+
+// pubsubBridgeActor forwards messages published to a topic to a plain callback handler,
+// without requiring the caller to define and spawn an Actor of their own. It exists purely
+// to bridge the actor-based topic pub/sub machinery (see topicActor) to non-actor code, e.g.
+// a websocket/SSE gateway handler.
+//
+// It subscribes to its topic exactly like any other actor subscriber (Subscribe/Watch/
+// Terminated), so dedup, retention, and cross-node dissemination semantics owned by topicActor
+// are untouched. A panic raised by the handler is recovered by the generic per-message panic
+// recovery every actor already has (see PID.recovery) and resumed by this actor's supervisor,
+// so a misbehaving handler never tears down the subscription.
+type pubsubBridgeActor struct {
+	topic         string
+	topicActorPID *PID
+	handler       func(ctx context.Context, message proto.Message)
+	logger        log.Logger
+}
+
+// enforce compilation error
+var _ Actor = (*pubsubBridgeActor)(nil)
+
+// newPubSubBridgeActor creates a new pub/sub bridge actor for the given topic.
+func newPubSubBridgeActor(topic string, topicActorPID *PID, handler func(ctx context.Context, message proto.Message)) Actor {
+	return &pubsubBridgeActor{
+		topic:         topic,
+		topicActorPID: topicActorPID,
+		handler:       handler,
+	}
+}
+
+// PreStart is called before the actor starts.
+func (x *pubsubBridgeActor) PreStart(*Context) error {
+	return nil
+}
+
+// Receive is called to process the message.
+func (x *pubsubBridgeActor) Receive(ctx *ReceiveContext) {
+	switch ctx.Message().(type) {
+	case *PostStart:
+		x.logger = ctx.Logger()
+		ctx.Tell(x.topicActorPID, NewSubscribe(x.topic))
+	case *SubscribeAck, *UnsubscribeAck, *Terminated:
+		// subscription lifecycle signals; nothing to forward to the handler
+	default:
+		x.dispatch(ctx)
+	}
+}
+
+// dispatch forwards a delivered topic message to the registered handler.
+func (x *pubsubBridgeActor) dispatch(ctx *ReceiveContext) {
+	message, ok := ctx.Message().(proto.Message)
+	if !ok {
+		x.logger.Warnf("pubsub bridge for topic=%q dropped a non-proto message of type %T", x.topic, ctx.Message())
+		return
+	}
+	x.handler(ctx.Context(), message)
+}
+
+// PostStop is called when the actor is stopped.
+func (x *pubsubBridgeActor) PostStop(*Context) error {
+	return nil
+}
+
+// SubscribeTopic registers a plain callback as a subscriber of the given topic. See the
+// ActorSystem interface documentation for details.
+func (x *actorSystem) SubscribeTopic(topic string, handler func(ctx context.Context, message proto.Message)) (Subscription, error) {
+	if !x.Running() {
+		return nil, gerrors.ErrActorSystemNotStarted
+	}
+
+	if handler == nil {
+		return nil, gerrors.ErrSubscribeHandlerRequired
+	}
+
+	topicActorPID := x.TopicActor()
+	if topicActorPID == nil {
+		return nil, gerrors.ErrPubSubDisabled
+	}
+
+	name := fmt.Sprintf("%s-%s", pubsubBridgeNamePrefix, uuid.NewString())
+	pid, err := x.Spawn(context.Background(), name,
+		newPubSubBridgeActor(topic, topicActorPID, handler),
+		asSystem(),
+		WithLongLived(),
+		WithRelocationDisabled(),
+		WithSupervisor(
+			supervisor.NewSupervisor(
+				supervisor.WithStrategy(supervisor.OneForOneStrategy),
+				supervisor.WithAnyErrorDirective(supervisor.ResumeDirective),
+			),
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pubsubBridgeSubscription{topic: topic, pid: pid}, nil
+}

--- a/actor/pubsub_bridge_test.go
+++ b/actor/pubsub_bridge_test.go
@@ -232,4 +232,118 @@ func TestSubscribeTopic(t *testing.T) {
 		require.ErrorIs(t, err, gerrors.ErrActorSystemNotStarted)
 		require.Nil(t, sub)
 	})
+
+	t.Run("A blocking handler delays its own subsequent deliveries without affecting another topic's bridge", func(t *testing.T) {
+		ctx := context.Background()
+		actorSystem, err := NewActorSystem("testSys", WithLogger(log.DiscardLogger), WithPubSub())
+		require.NoError(t, err)
+		require.NoError(t, actorSystem.Start(ctx))
+
+		pause.For(time.Second)
+
+		blockTopic := "block-topic"
+		otherTopic := "other-topic"
+
+		unblock := make(chan struct{})
+		var blockingOrder []string
+		var blockingMu sync.Mutex
+
+		blockingSub, err := actorSystem.SubscribeTopic(blockTopic, func(_ context.Context, message proto.Message) {
+			count := message.(*testpb.TestCount)
+			if count.GetValue() == 1 {
+				// hold the bridge's single mailbox goroutine until told to
+				// proceed, so a second published message must queue behind it
+				<-unblock
+			}
+			blockingMu.Lock()
+			blockingOrder = append(blockingOrder, "block")
+			blockingMu.Unlock()
+		})
+		require.NoError(t, err)
+
+		var otherCounter atomic.Int64
+		otherSub, err := actorSystem.SubscribeTopic(otherTopic, func(context.Context, proto.Message) {
+			otherCounter.Inc()
+		})
+		require.NoError(t, err)
+
+		pause.For(500 * time.Millisecond)
+
+		publisher, err := actorSystem.Spawn(ctx, "publisher", NewMockSubscriber())
+		require.NoError(t, err)
+
+		require.NoError(t, publisher.Tell(ctx, actorSystem.TopicActor(), NewPublish("m1", blockTopic, &testpb.TestCount{Value: 1})))
+		require.NoError(t, publisher.Tell(ctx, actorSystem.TopicActor(), NewPublish("m2", blockTopic, &testpb.TestCount{Value: 2})))
+
+		pause.For(300 * time.Millisecond)
+
+		// the blocked bridge must not stall delivery to an unrelated topic's bridge
+		require.NoError(t, publisher.Tell(ctx, actorSystem.TopicActor(), NewPublish("m3", otherTopic, new(testpb.TestCount))))
+		pause.For(300 * time.Millisecond)
+		require.EqualValues(t, 1, otherCounter.Load(), "the other topic's bridge must be delivered to while the blocking topic's bridge is stuck")
+
+		close(unblock)
+		pause.For(500 * time.Millisecond)
+
+		blockingMu.Lock()
+		require.Equal(t, []string{"block", "block"}, blockingOrder, "both messages must eventually be delivered in order, without loss")
+		blockingMu.Unlock()
+
+		require.NoError(t, blockingSub.Close())
+		require.NoError(t, otherSub.Close())
+		require.NoError(t, actorSystem.Stop(ctx))
+	})
+
+	t.Run("Closing a subscription twice is a safe no-op", func(t *testing.T) {
+		ctx := context.Background()
+		actorSystem, err := NewActorSystem("testSys", WithLogger(log.DiscardLogger), WithPubSub())
+		require.NoError(t, err)
+		require.NoError(t, actorSystem.Start(ctx))
+
+		pause.For(time.Second)
+
+		sub, err := actorSystem.SubscribeTopic("test-topic", func(context.Context, proto.Message) {})
+		require.NoError(t, err)
+
+		require.NoError(t, sub.Close())
+		require.NoError(t, sub.Close(), "a second Close must not error")
+
+		require.NoError(t, actorSystem.Stop(ctx))
+	})
+
+	t.Run("Subscribing the same callback to a topic twice delivers each publish twice", func(t *testing.T) {
+		// SubscribeTopic is not idempotent: each call spawns its own bridge
+		// actor and registers it as an independent subscriber, so subscribing
+		// twice is indistinguishable from two different subscribers and both
+		// receive every publish.
+		ctx := context.Background()
+		actorSystem, err := NewActorSystem("testSys", WithLogger(log.DiscardLogger), WithPubSub())
+		require.NoError(t, err)
+		require.NoError(t, actorSystem.Start(ctx))
+
+		pause.For(time.Second)
+
+		var counter atomic.Int64
+		topic := "test-topic"
+		handler := func(context.Context, proto.Message) { counter.Inc() }
+
+		sub1, err := actorSystem.SubscribeTopic(topic, handler)
+		require.NoError(t, err)
+		sub2, err := actorSystem.SubscribeTopic(topic, handler)
+		require.NoError(t, err)
+
+		pause.For(500 * time.Millisecond)
+
+		publisher, err := actorSystem.Spawn(ctx, "publisher", NewMockSubscriber())
+		require.NoError(t, err)
+
+		require.NoError(t, publisher.Tell(ctx, actorSystem.TopicActor(), NewPublish("message1", topic, new(testpb.TestCount))))
+		pause.For(500 * time.Millisecond)
+
+		require.EqualValues(t, 2, counter.Load(), "each independent subscription must be delivered to")
+
+		require.NoError(t, sub1.Close())
+		require.NoError(t, sub2.Close())
+		require.NoError(t, actorSystem.Stop(ctx))
+	})
 }

--- a/actor/pubsub_bridge_test.go
+++ b/actor/pubsub_bridge_test.go
@@ -1,0 +1,235 @@
+// MIT License
+//
+// Copyright (c) 2022-2026 GoAkt Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package actor
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+	"google.golang.org/protobuf/proto"
+
+	gerrors "github.com/tochemey/goakt/v4/errors"
+	"github.com/tochemey/goakt/v4/internal/pause"
+	"github.com/tochemey/goakt/v4/log"
+	"github.com/tochemey/goakt/v4/test/data/testpb"
+)
+
+func TestSubscribeTopic(t *testing.T) {
+	t.Run("With happy path", func(t *testing.T) {
+		ctx := context.Background()
+		actorSystem, err := NewActorSystem("testSys", WithLogger(log.DiscardLogger), WithPubSub())
+		require.NoError(t, err)
+		require.NoError(t, actorSystem.Start(ctx))
+
+		pause.For(time.Second)
+
+		var mu sync.Mutex
+		var received []proto.Message
+
+		topic := "test-topic"
+		sub, err := actorSystem.SubscribeTopic(topic, func(_ context.Context, message proto.Message) {
+			mu.Lock()
+			received = append(received, message)
+			mu.Unlock()
+		})
+		require.NoError(t, err)
+		require.NotNil(t, sub)
+		require.Equal(t, topic, sub.Topic())
+
+		pause.For(500 * time.Millisecond)
+
+		publisher, err := actorSystem.Spawn(ctx, "publisher", NewMockSubscriber())
+		require.NoError(t, err)
+
+		message := NewPublish("message1", topic, new(testpb.TestCount))
+		require.NoError(t, publisher.Tell(ctx, actorSystem.TopicActor(), message))
+
+		pause.For(500 * time.Millisecond)
+
+		mu.Lock()
+		require.Len(t, received, 1)
+		assert.True(t, proto.Equal(new(testpb.TestCount), received[0]))
+		mu.Unlock()
+
+		require.NoError(t, sub.Close())
+		require.NoError(t, actorSystem.Stop(ctx))
+	})
+
+	t.Run("With Unsubscribe stopping delivery", func(t *testing.T) {
+		ctx := context.Background()
+		actorSystem, err := NewActorSystem("testSys", WithLogger(log.DiscardLogger), WithPubSub())
+		require.NoError(t, err)
+		require.NoError(t, actorSystem.Start(ctx))
+
+		pause.For(time.Second)
+
+		var counter atomic.Int64
+		topic := "test-topic"
+		sub, err := actorSystem.SubscribeTopic(topic, func(context.Context, proto.Message) {
+			counter.Inc()
+		})
+		require.NoError(t, err)
+
+		pause.For(500 * time.Millisecond)
+
+		publisher, err := actorSystem.Spawn(ctx, "publisher", NewMockSubscriber())
+		require.NoError(t, err)
+
+		require.NoError(t, publisher.Tell(ctx, actorSystem.TopicActor(), NewPublish("message1", topic, new(testpb.TestCount))))
+		pause.For(500 * time.Millisecond)
+		require.EqualValues(t, 1, counter.Load())
+
+		// unsubscribe: the bridge actor is shut down and the topic actor's death
+		// watch removes it from the topic's subscriber registry
+		require.NoError(t, sub.Unsubscribe())
+		// calling it again is a no-op and must not error
+		require.NoError(t, sub.Unsubscribe())
+		pause.For(500 * time.Millisecond)
+
+		topicActor := actorSystem.TopicActor().Actor().(*topicActor)
+		subscribers, ok := topicActor.topics.Get(topic)
+		require.True(t, ok)
+		require.Zero(t, subscribers.Len())
+
+		require.NoError(t, publisher.Tell(ctx, actorSystem.TopicActor(), NewPublish("message2", topic, new(testpb.TestCount))))
+		pause.For(500 * time.Millisecond)
+		require.EqualValues(t, 1, counter.Load())
+
+		require.NoError(t, actorSystem.Stop(ctx))
+	})
+
+	t.Run("With a panicking handler resumed and not killed", func(t *testing.T) {
+		ctx := context.Background()
+		actorSystem, err := NewActorSystem("testSys", WithLogger(log.DiscardLogger), WithPubSub())
+		require.NoError(t, err)
+		require.NoError(t, actorSystem.Start(ctx))
+
+		pause.For(time.Second)
+
+		var counter atomic.Int64
+		topic := "test-topic"
+		sub, err := actorSystem.SubscribeTopic(topic, func(context.Context, proto.Message) {
+			counter.Inc()
+			panic("boom")
+		})
+		require.NoError(t, err)
+
+		pause.For(500 * time.Millisecond)
+
+		publisher, err := actorSystem.Spawn(ctx, "publisher", NewMockSubscriber())
+		require.NoError(t, err)
+
+		require.NoError(t, publisher.Tell(ctx, actorSystem.TopicActor(), NewPublish("message1", topic, new(testpb.TestCount))))
+		pause.For(500 * time.Millisecond)
+		require.EqualValues(t, 1, counter.Load())
+
+		// the bridge actor must still be alive and subscribed after the panic
+		require.NoError(t, publisher.Tell(ctx, actorSystem.TopicActor(), NewPublish("message2", topic, new(testpb.TestCount))))
+		pause.For(500 * time.Millisecond)
+		require.EqualValues(t, 2, counter.Load())
+
+		require.NoError(t, sub.Close())
+		require.NoError(t, actorSystem.Stop(ctx))
+	})
+
+	t.Run("With a non-proto message dropped without killing the bridge", func(t *testing.T) {
+		ctx := context.Background()
+		actorSystem, err := NewActorSystem("testSys", WithLogger(log.DiscardLogger), WithPubSub())
+		require.NoError(t, err)
+		require.NoError(t, actorSystem.Start(ctx))
+
+		pause.For(time.Second)
+
+		var counter atomic.Int64
+		topic := "test-topic"
+		sub, err := actorSystem.SubscribeTopic(topic, func(context.Context, proto.Message) {
+			counter.Inc()
+		})
+		require.NoError(t, err)
+
+		pause.For(500 * time.Millisecond)
+
+		publisher, err := actorSystem.Spawn(ctx, "publisher", NewMockSubscriber())
+		require.NoError(t, err)
+
+		// a locally published non-proto payload cannot be forwarded to the handler;
+		// it must be dropped without affecting the bridge
+		require.NoError(t, publisher.Tell(ctx, actorSystem.TopicActor(), NewPublish("message1", topic, "not-a-proto-message")))
+		pause.For(500 * time.Millisecond)
+		require.Zero(t, counter.Load())
+
+		require.NoError(t, publisher.Tell(ctx, actorSystem.TopicActor(), NewPublish("message2", topic, new(testpb.TestCount))))
+		pause.For(500 * time.Millisecond)
+		require.EqualValues(t, 1, counter.Load())
+
+		require.NoError(t, sub.Close())
+		require.NoError(t, actorSystem.Stop(ctx))
+	})
+
+	t.Run("With PubSub disabled", func(t *testing.T) {
+		ctx := context.Background()
+		actorSystem, err := NewActorSystem("testSys", WithLogger(log.DiscardLogger))
+		require.NoError(t, err)
+		require.NoError(t, actorSystem.Start(ctx))
+
+		pause.For(time.Second)
+
+		sub, err := actorSystem.SubscribeTopic("test-topic", func(context.Context, proto.Message) {})
+		require.Error(t, err)
+		require.ErrorIs(t, err, gerrors.ErrPubSubDisabled)
+		require.Nil(t, sub)
+
+		require.NoError(t, actorSystem.Stop(ctx))
+	})
+
+	t.Run("With a nil handler", func(t *testing.T) {
+		ctx := context.Background()
+		actorSystem, err := NewActorSystem("testSys", WithLogger(log.DiscardLogger), WithPubSub())
+		require.NoError(t, err)
+		require.NoError(t, actorSystem.Start(ctx))
+
+		pause.For(time.Second)
+
+		sub, err := actorSystem.SubscribeTopic("test-topic", nil)
+		require.Error(t, err)
+		require.ErrorIs(t, err, gerrors.ErrSubscribeHandlerRequired)
+		require.Nil(t, sub)
+
+		require.NoError(t, actorSystem.Stop(ctx))
+	})
+
+	t.Run("With the actor system not started", func(t *testing.T) {
+		actorSystem, err := NewActorSystem("testSys", WithLogger(log.DiscardLogger), WithPubSub())
+		require.NoError(t, err)
+
+		sub, err := actorSystem.SubscribeTopic("test-topic", func(context.Context, proto.Message) {})
+		require.Error(t, err)
+		require.ErrorIs(t, err, gerrors.ErrActorSystemNotStarted)
+		require.Nil(t, sub)
+	})
+}

--- a/benchmark/doc.md
+++ b/benchmark/doc.md
@@ -69,6 +69,12 @@ go test -run=^$ -bench='Throughput$' -count=5 ./benchmark/
 go test -run=^$ -bench=^BenchmarkActorMemoryFootprint$ -benchmem ./benchmark/
 ```
 
+### PubSubBridgeDelivery — SubscribeTopic (non-actor pub/sub) delivery throughput
+
+```
+go test -run=^$ -bench=^BenchmarkPubSubBridgeDelivery$ -count=10 ./benchmark/
+```
+
 ### RemoteTellThroughput — TCP send across 10 systems for 10 s
 
 ```

--- a/benchmark/pubsub_bridge_test.go
+++ b/benchmark/pubsub_bridge_test.go
@@ -1,0 +1,96 @@
+// MIT License
+//
+// Copyright (c) 2022-2026 GoAkt Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package benchmark
+
+import (
+	"context"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/tochemey/goakt/v4/actor"
+	"github.com/tochemey/goakt/v4/log"
+	"github.com/tochemey/goakt/v4/test/data/testpb"
+)
+
+// BenchmarkPubSubBridgeDelivery measures end-to-end throughput of the
+// non-actor pub/sub bridge (ActorSystem.SubscribeTopic): a Publish sent to
+// the topic actor, forwarded to the bridge's internal subscriber actor, and
+// delivered to a plain callback. It is the SubscribeTopic counterpart of
+// BenchmarkTell — same dispatch path plus one extra hop through topicActor.
+func BenchmarkPubSubBridgeDelivery(b *testing.B) {
+	ctx := context.Background()
+
+	actorSystem, err := actor.NewActorSystem("bench",
+		actor.WithLogger(log.DiscardLogger),
+		actor.WithActorInitMaxRetries(1),
+		actor.WithPubSub())
+	if err != nil {
+		b.Fatalf("failed to create actor system: %v", err)
+	}
+	if err := actorSystem.Start(ctx); err != nil {
+		b.Fatalf("failed to start actor system: %v", err)
+	}
+	b.Cleanup(func() { _ = actorSystem.Stop(ctx) })
+
+	const topic = "bench-topic"
+
+	var received int64
+	target := int64(b.N)
+	done := make(chan struct{})
+
+	sub, err := actorSystem.SubscribeTopic(topic, func(context.Context, proto.Message) {
+		if atomic.AddInt64(&received, 1) == target {
+			close(done)
+		}
+	})
+	if err != nil {
+		b.Fatalf("failed to subscribe to topic: %v", err)
+	}
+	b.Cleanup(func() { _ = sub.Close() })
+
+	publisher, err := actorSystem.Spawn(ctx, "publisher", new(Actor))
+	if err != nil {
+		b.Fatalf("failed to spawn publisher: %v", err)
+	}
+
+	var seq int64
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			id := strconv.FormatInt(atomic.AddInt64(&seq, 1), 10)
+			message := actor.NewPublish(id, topic, new(testpb.TestCount))
+			if err := publisher.Tell(ctx, actorSystem.TopicActor(), message); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	<-done
+	b.StopTimer()
+	messagesPerSec := float64(b.N) / b.Elapsed().Seconds()
+	b.ReportMetric(messagesPerSec, "messages/sec")
+}

--- a/docs/advanced/pubsub-bridge.mdx
+++ b/docs/advanced/pubsub-bridge.mdx
@@ -1,0 +1,107 @@
+---
+title: Non-Actor PubSub Subscriptions
+description: Subscribe a plain callback to a pub/sub topic without defining or spawning an Actor.
+sidebarTitle: "PubSub Bridge"
+---
+
+Subscribing to a [PubSub](/advanced/pubsub) topic normally requires an actor: you define an
+`Actor`, spawn it, send it a `Subscribe` message, and match on the published message type in
+`Receive`. That is the right shape when the subscriber is itself part of your actor graph, but it
+is unnecessary ceremony for gateway-style code — a websocket or SSE handler, for example — that
+only needs to forward whatever is published on a topic somewhere else.
+
+`ActorSystem.SubscribeTopic` registers a plain Go callback as a topic subscriber instead.
+
+## SubscribeTopic
+
+```go
+sub, err := system.SubscribeTopic("orders", func(ctx context.Context, msg proto.Message) {
+    // forward msg to a websocket connection, log it, push it to a channel, etc.
+})
+if err != nil {
+    log.Fatal(err)
+}
+defer sub.Close()
+```
+
+| Method                                | Purpose                                                                        |
+|----------------------------------------|--------------------------------------------------------------------------------|
+| `ActorSystem.SubscribeTopic(topic, handler)` | Registers handler as a subscriber of topic. Returns a `Subscription` or an error. |
+
+Requirements:
+
+- PubSub mode must be enabled, either via `WithPubSub()` or because cluster mode is enabled. If it
+  is not, `SubscribeTopic` returns `errors.ErrPubSubDisabled`.
+- `handler` must not be nil, otherwise `errors.ErrSubscribeHandlerRequired` is returned.
+- The actor system must be running, otherwise `errors.ErrActorSystemNotStarted` is returned.
+
+## Subscription
+
+```go
+type Subscription interface {
+    Topic() string
+    Unsubscribe() error
+    Close() error
+}
+```
+
+`Unsubscribe` and `Close` are equivalent: either stops delivery to the handler and releases the
+internal resources backing the subscription. Both are safe to call more than once — only the first
+call has any effect.
+
+## How it works
+
+`SubscribeTopic` spawns an internally managed bridge actor that subscribes to the topic exactly
+the way any other actor subscriber does — it sends `Subscribe` to [`TopicActor()`](/advanced/pubsub)
+and is watched by it like any other subscriber. This means:
+
+- **Delivery, ordering, and dedup are untouched.** The bridge is just another subscriber from
+  `topicActor`'s point of view; the retention/dedup window configured with `WithMessageRetention`
+  applies identically.
+- **Cross-node dissemination is untouched.** In cluster mode, a message published on one node
+  reaches a `SubscribeTopic` handler registered on another node through the same `TopicMessage`
+  path actor-to-actor pub/sub uses.
+- **Unsubscribing shuts the bridge actor down.** `topicActor` watches every subscriber and removes
+  it from its registry when the subscriber terminates, so `Unsubscribe`/`Close` simply stops the
+  bridge actor and relies on that existing cleanup path.
+
+<Note>
+The handler is invoked on the bridge actor's own goroutine, one message at a time — the same
+sequencing guarantee a `Receive` method gets. Keep it fast, or hand off blocking work (e.g. to a
+buffered channel) instead of doing it inline.
+</Note>
+
+<Warning>
+A panic raised inside handler is recovered like any other actor panic and does not tear down the
+subscription — the bridge actor resumes and keeps delivering later messages. It is still your
+responsibility to avoid leaving shared state inconsistent if your handler panics mid-update.
+</Warning>
+
+## Non-proto payloads
+
+`SubscribeTopic`'s handler signature takes a `proto.Message`, matching the type PubSub uses for
+cross-node dissemination. If something publishes a payload that does not implement `proto.Message`
+to a topic a bridge is subscribed to, the bridge drops it (and logs a warning) instead of invoking
+the handler — the bridge itself is unaffected.
+
+## Example: a websocket gateway
+
+```go
+sub, err := system.SubscribeTopic("orders", func(_ context.Context, msg proto.Message) {
+    event, ok := msg.(*ordersv1.OrderCreated)
+    if !ok {
+        return
+    }
+    payload, _ := protojson.Marshal(event)
+    wsConn.WriteMessage(websocket.TextMessage, payload)
+})
+if err != nil {
+    return err
+}
+
+// when the websocket connection closes:
+defer sub.Close()
+```
+
+No actor definition, no `Receive` switch, no manual `Subscribe`/`Unsubscribe` message plumbing —
+just a callback tied to the lifetime of the connection it serves.

--- a/docs/advanced/pubsub.mdx
+++ b/docs/advanced/pubsub.mdx
@@ -143,3 +143,9 @@ func (a *OrderService) Receive(ctx *ReceiveContext) {
 | Subscribers | External (monitoring, logging)        | Your actors                          |
 | API         | `Subscribe()` / `Unsubscribe()`       | Messages to `TopicActor()`           |
 | Option      | Always present                        | `WithPubSub()` or cluster            |
+
+<Note>
+Need a subscriber that is not an actor — a websocket/SSE handler, for example? See
+[Non-Actor PubSub Subscriptions](/advanced/pubsub-bridge) for `ActorSystem.SubscribeTopic`, a
+plain-callback subscription built on top of the same topic actor described above.
+</Note>

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -256,6 +256,14 @@ var (
 
 	// ErrInvalidKinds is returned when the child and parent kinds are different.
 	ErrInvalidKinds = errors.New("child and parent kinds must be the same")
+
+	// ErrPubSubDisabled indicates an attempt to use pub-sub features when PubSub mode
+	// is not enabled for the actor system. Enable it with WithPubSub, or by enabling
+	// cluster mode.
+	ErrPubSubDisabled = errors.New("pubsub is not enabled")
+
+	// ErrSubscribeHandlerRequired is returned when SubscribeTopic is called with a nil handler.
+	ErrSubscribeHandlerRequired = errors.New("subscribe handler is required")
 )
 
 // NewErrInvalidTCPAddress formats an ErrInvalidTCPAddress with the given address.

--- a/testkit/pubsub_bridge_test.go
+++ b/testkit/pubsub_bridge_test.go
@@ -1,0 +1,96 @@
+// MIT License
+//
+// Copyright (c) 2022-2026 GoAkt Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package testkit
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/tochemey/goakt/v4/actor"
+	"github.com/tochemey/goakt/v4/internal/pause"
+	"github.com/tochemey/goakt/v4/log"
+	"github.com/tochemey/goakt/v4/test/data/testpb"
+)
+
+// TestPubSubBridgeCrossNode verifies that ActorSystem.SubscribeTopic (the non-actor
+// pub/sub bridge) receives messages published on a different cluster node, reusing
+// the same cross-node dissemination path as actor-to-actor pub/sub.
+func TestPubSubBridgeCrossNode(t *testing.T) {
+	ctx := context.Background()
+	multi := NewMultiNodes(t, log.DiscardLogger, []actor.Actor{&pinger{}}, nil)
+	multi.Start()
+	t.Cleanup(multi.Stop)
+
+	node1 := multi.StartNode(ctx, "node-1")
+	node2 := multi.StartNode(ctx, "node-2")
+
+	topic := "cross-node-topic"
+
+	var mu sync.Mutex
+	var received []*testpb.TestLog
+
+	sub, err := node1.ActorSystem().SubscribeTopic(topic, func(_ context.Context, message proto.Message) {
+		if msg, ok := message.(*testpb.TestLog); ok {
+			mu.Lock()
+			received = append(received, msg)
+			mu.Unlock()
+		}
+	})
+	require.NoError(t, err)
+	require.NotNil(t, sub)
+	require.Equal(t, topic, sub.Topic())
+	t.Cleanup(func() { _ = sub.Close() })
+
+	publisher, err := node2.ActorSystem().Spawn(ctx, "publisher", &pinger{})
+	require.NoError(t, err)
+
+	message := actor.NewPublish("cross-node-message-1", topic, &testpb.TestLog{Text: "hello from node-2"})
+	require.NoError(t, publisher.Tell(ctx, node2.ActorSystem().TopicActor(), message))
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(received) == 1
+	}, 10*time.Second, 100*time.Millisecond)
+
+	mu.Lock()
+	require.Equal(t, "hello from node-2", received[0].GetText())
+	mu.Unlock()
+
+	// unsubscribing stops further delivery to this node's bridge
+	require.NoError(t, sub.Close())
+
+	message2 := actor.NewPublish("cross-node-message-2", topic, &testpb.TestLog{Text: "should not arrive"})
+	require.NoError(t, publisher.Tell(ctx, node2.ActorSystem().TopicActor(), message2))
+
+	pause.For(2 * time.Second)
+
+	mu.Lock()
+	require.Len(t, received, 1)
+	mu.Unlock()
+}


### PR DESCRIPTION
Closes #1237

Adds a non-actor subscription bridge to PubSub: `ActorSystem.SubscribeTopic(topic, func(ctx context.Context, msg proto.Message)) (Subscription, error)` with `Unsubscribe`/`Close` on the returned handle.

Internally each subscription is a managed bridge actor that subscribes to the topic actor exactly like any other subscriber, so delivery ordering, the dedup/retention window, and cross-node dissemination semantics are unchanged - this is ergonomic surface, not new semantics. Handler panics are recovered and resumed so a bad callback cannot kill the subscription; a typed error is returned when PubSub is not enabled.

Testing: unit tests (happy path, unsubscribe stops delivery, panicking handler survives, blocking handler queues without loss, double close is a no-op, duplicate subscribe semantics pinned) plus a MultiNodes cross-node delivery test and a delivery throughput benchmark. `make lint` and the affected package suites pass with `-race`.

Docs: new PubSub bridge page.
