### PR TITLE
fix: detach remoting server base context from Start cancelation (#1252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### 🔧 Fixes
+
+- **Remoting no longer inherits cancelation from the `Start` context** ([#1252](https://github.com/Tochemey/goakt/issues/1252)). The remoting server stored the startup context as its long-lived base context, so a bounded `Start(ctx)` (a DI OnStart hook, a startup timeout) expiring after startup poisoned every inbound handler context: all remote operations against the node failed with `context deadline exceeded` until the process restarted. The server base context is now detached via `context.WithoutCancel`, preserving context values while leaving the server's lifetime to `Stop()`.
+
 ## v4.3.0 - 2026-07-09
 
 ### ✨ Features

--- a/actor/remote_server.go
+++ b/actor/remote_server.go
@@ -1543,8 +1543,10 @@ func (x *actorSystem) startRemoteServer(ctx context.Context) error {
 		serverOpts = append(serverOpts, inet.WithProtoServerIdleTimeout(x.remoteConfig.IdleTimeout()))
 	}
 
-	// Add context to the server.
-	serverOpts = append(serverOpts, inet.WithProtoServerContext(ctx))
+	// Detach the server's base context from Start's cancelation/deadline: the server's
+	// lifetime is governed by Stop, and a bounded startup context (a DI OnStart hook, a
+	// startup timeout) expiring later must not poison every inbound handler context.
+	serverOpts = append(serverOpts, inet.WithProtoServerContext(context.WithoutCancel(ctx)))
 
 	// Add panic recovery so a misbehaving handler does not crash the connection.
 	serverOpts = append(serverOpts, inet.WithProtoServerPanicHandler(func(typeName protoreflect.FullName, recovered any) {

--- a/actor/remote_server_test.go
+++ b/actor/remote_server_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/tochemey/goakt/v4/log"
 	"github.com/tochemey/goakt/v4/passivation"
 	"github.com/tochemey/goakt/v4/remote"
+	"github.com/tochemey/goakt/v4/test/data/testpb"
 )
 
 // newRemoteServerTestSystem builds the minimal actorSystem needed to unit-test
@@ -2550,4 +2551,44 @@ func TestRemoteUnWatchHandler(t *testing.T) {
 
 		require.Empty(t, sys.remoteWatches.watchersFor(watcheeID))
 	})
+}
+
+// TestRemotingSurvivesExpiredStartContext pins the fix for #1252: the remoting server
+// must not inherit cancelation from the Start context, so a bounded startup context
+// expiring after startup completed leaves inbound remoting fully functional.
+func TestRemotingSurvivesExpiredStartContext(t *testing.T) {
+	remotingPort := inet.Get(1)[0]
+
+	sys, err := NewActorSystem("test",
+		WithLogger(log.DiscardLogger),
+		WithRemote(remote.NewConfig("127.0.0.1", remotingPort)),
+	)
+	require.NoError(t, err)
+
+	startCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	require.NoError(t, sys.Start(startCtx))
+
+	ctx := context.TODO()
+	t.Cleanup(func() { require.NoError(t, sys.Stop(ctx)) })
+
+	actorName := "test"
+	pid, err := sys.Spawn(ctx, actorName, NewMockActor())
+	require.NoError(t, err)
+	require.NotNil(t, pid)
+
+	// let the startup budget expire; before the fix every handler context was
+	// born already DeadlineExceeded from this point on
+	pause.For(time.Second)
+
+	remoting := remoteclient.NewClient()
+	t.Cleanup(remoting.Close)
+
+	addr, err := remoting.RemoteLookup(ctx, sys.Host(), int(sys.Port()), actorName)
+	require.NoError(t, err)
+	require.NotNil(t, addr)
+
+	reply, err := remoting.RemoteAsk(ctx, address.NoSender(), addr, new(testpb.TestReply), 20*time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, reply)
 }

--- a/playground/issue-1252/README.md
+++ b/playground/issue-1252/README.md
@@ -1,0 +1,16 @@
+# Issue 1252: remoting poisoned by an expired Start context
+
+Starting a remoting-enabled system with a bounded context (`context.WithTimeout` around `Start`, the pattern DI frameworks hand to OnStart hooks) used to store that context as the remoting server's long-lived base context. Once the startup budget elapsed, every inbound handler context was born already `DeadlineExceeded`, so every remote operation against the node failed with `context deadline exceeded` / `request timed out` until the process restarted - while the process itself looked healthy.
+
+## Expected vs actual
+
+- **Expected**: the server's lifetime is governed by `Stop()`; a startup context expiring after startup completed has no effect on a running node.
+- **Actual (before the fix)**: all remote lookups/asks against the node fail permanently once the startup context expires.
+
+## Run
+
+```bash
+go run ./playground/issue-1252
+```
+
+Prints `OK: remoting survives an expired Start context` with the fix (`startRemoteServer` detaches the server base context via `context.WithoutCancel`); before the fix it exits with a `REPRO (broken)` fatal on the first remote call.

--- a/playground/issue-1252/main.go
+++ b/playground/issue-1252/main.go
@@ -1,0 +1,74 @@
+// Package main reproduces github.com/Tochemey/goakt/issues/1252: the remoting
+// server used to inherit cancelation from the Start context, so a bounded
+// startup context expiring after startup poisoned every inbound handler
+// context and all remote operations failed with "context deadline exceeded"
+// until the process restarted. With the fix, this sample prints OK.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/tochemey/goakt/v4/actor"
+	"github.com/tochemey/goakt/v4/internal/address"
+	inet "github.com/tochemey/goakt/v4/internal/net"
+	"github.com/tochemey/goakt/v4/internal/remoteclient"
+	goaktlog "github.com/tochemey/goakt/v4/log"
+	"github.com/tochemey/goakt/v4/remote"
+	"github.com/tochemey/goakt/v4/test/data/testpb"
+)
+
+type echo struct{}
+
+func (e *echo) PreStart(*actor.Context) error { return nil }
+func (e *echo) PostStop(*actor.Context) error { return nil }
+func (e *echo) Receive(ctx *actor.ReceiveContext) {
+	switch ctx.Message().(type) {
+	case *testpb.TestReply:
+		ctx.Response(new(testpb.Reply))
+	default:
+		ctx.Unhandled()
+	}
+}
+
+func main() {
+	port := inet.Get(1)[0]
+	system, err := actor.NewActorSystem("issue1252",
+		actor.WithLogger(goaktlog.DiscardLogger),
+		actor.WithRemote(remote.NewConfig("127.0.0.1", port)),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// the common footgun: a bounded startup context (DI OnStart hook, startup timeout)
+	startCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := system.Start(startCtx); err != nil {
+		log.Fatal(err)
+	}
+	defer func() { _ = system.Stop(context.Background()) }()
+
+	ctx := context.Background()
+	if _, err := system.Spawn(ctx, "echo", &echo{}); err != nil {
+		log.Fatal(err)
+	}
+
+	// let the startup budget expire; before the fix, remoting on this node is
+	// permanently poisoned from this moment on
+	time.Sleep(1500 * time.Millisecond)
+
+	client := remoteclient.NewClient()
+	defer client.Close()
+
+	addr, err := client.RemoteLookup(ctx, system.Host(), int(system.Port()), "echo")
+	if err != nil {
+		log.Fatalf("REPRO (broken): remote lookup failed after start context expired: %v", err)
+	}
+	if _, err := client.RemoteAsk(ctx, address.NoSender(), addr, new(testpb.TestReply), 10*time.Second); err != nil {
+		log.Fatalf("REPRO (broken): remote ask failed after start context expired: %v", err)
+	}
+	fmt.Println("OK: remoting survives an expired Start context")
+}

--- a/playground/issue-1252/main.go
+++ b/playground/issue-1252/main.go
@@ -1,3 +1,25 @@
+// MIT License
+//
+// Copyright (c) 2022-2026 GoAkt Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 // Package main reproduces github.com/Tochemey/goakt/issues/1252: the remoting
 // server used to inherit cancelation from the Start context, so a bounded
 // startup context expiring after startup poisoned every inbound handler


### PR DESCRIPTION
Closes #1252

One-line fix: `startRemoteServer` now passes `context.WithoutCancel(ctx)` as the proto server's base context. Context values (tracing, metadata) still flow; cancelation and deadline no longer do - the server's lifetime is governed by `Stop()`, exactly as before, so nothing else changes.

Why it matters: a bounded startup context (`context.WithTimeout` around `Start`, the pattern DI frameworks hand to OnStart hooks) used to become the parent of every inbound handler context forever. Once the startup budget elapsed, `deadlineContext` rebasing the client's propagated deadline onto the dead parent produced handler contexts that were born `DeadlineExceeded`, and every remote operation against the node failed with `context deadline exceeded` / `request timed out` until restart - while the process looked healthy. Present since v4.2.12; hit in production.

Testing: `TestRemotingSurvivesExpiredStartContext` (actor package) starts a remoting-enabled system with a 500ms startup context, waits past expiry, and asserts RemoteLookup + RemoteAsk still succeed - verified to FAIL without the fix and PASS with it. `playground/issue-1252` is a self-validating reproduction per the contributing guide. Changelog entry added under Unreleased.
