### PR TITLE
fix: kubernetes discovery of not-ready pods (#1265)

### DIFF
--- a/discovery/kubernetes/README.md
+++ b/discovery/kubernetes/README.md
@@ -52,8 +52,19 @@ type Provider interface {
 
 1. **Initialize**: Validate config and pre-compute the label selector; no API connection yet.
 2. **Register**: Load in-cluster config (`rest.InClusterConfig()`); create the Kubernetes client.
-3. **DiscoverPeers**: List pods in the namespace matching `PodLabels` and `status.phase=Running`; for each ready pod, read the port named `DiscoveryPortName` and return `podIP:port`.
+3. **DiscoverPeers**: List pods in the namespace matching `PodLabels` and `status.phase=Running`; for each candidate pod, read the port named `DiscoveryPortName` and return `podIP:port`.
 4. **Deregister**: Mark the provider as uninitialized.
+
+### Peer Filtering
+
+`DiscoverPeers` applies the following filters to the listed pods:
+
+- **Running phase required**: pods are listed with `status.phase=Running`.
+- **Readiness not required**: the `Ready` condition is deliberately ignored. On a cold start no pod is Ready until its actor system has joined the cluster, so gating discovery on readiness would prevent any cluster from ever forming (split brain with quorum 1, bootstrap deadlock with quorum > 1). Dead peers are rejected by the memberlist failure detector instead.
+- **Terminating pods excluded**: pods with a `deletionTimestamp` keep `status.phase=Running` until their containers exit; they are skipped so rolling updates do not feed dying IPs to memberlist.
+- **IP-less pods excluded**: pods without an assigned `status.podIP` cannot be dialed.
+
+An empty filtered result returns `ErrNoPodsAvailable`. Once the kubelet reports the calling pod `Running`, that pod must at minimum discover itself, so an empty list means API status lag; the error makes the cluster engine retry the join instead of bootstrapping a standalone cluster.
 
 ```
     Pod A                                    Pod B
@@ -101,8 +112,11 @@ provider := kubernetes.NewDiscovery(config)
 clusterConfig := actor.NewClusterConfig().
     WithDiscovery(provider).
     WithDiscoveryPort(7946).
+    WithMinimumPeersQuorum(2).
     WithKinds(myActor)
 ```
+
+For production deployments, set `WithMinimumPeersQuorum` to a majority of the replica count (e.g. 2 for 3 replicas). With the default quorum of 1, a node that cannot reach its peers is allowed to operate as a single-node cluster.
 
 ---
 

--- a/discovery/kubernetes/discovery.go
+++ b/discovery/kubernetes/discovery.go
@@ -24,6 +24,7 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -43,6 +44,13 @@ import (
 )
 
 const discoverPeersTimeout = 30 * time.Second
+
+// ErrNoPodsAvailable is returned by DiscoverPeers when the pod listing yields no
+// usable peer address. Once the kubelet reports the calling pod Running, that pod
+// must at minimum discover itself, so an empty result indicates Kubernetes API
+// status lag. Callers should treat it as retryable instead of bootstrapping a
+// standalone cluster.
+var ErrNoPodsAvailable = errors.New("no running pods with a usable address found")
 
 // Discovery represents the kubernetes discovery
 type Discovery struct {
@@ -136,6 +144,15 @@ func (d *Discovery) Deregister() error {
 }
 
 // DiscoverPeers returns a list of known nodes.
+//
+// Candidate pods are matched by the configured labels and status.phase=Running.
+// The Ready condition is deliberately not required: on a cold start no pod is
+// Ready until its actor system has joined the cluster, so gating discovery on
+// readiness would prevent any cluster from ever forming. Liveness of candidates
+// is delegated to the memberlist failure detector. Terminating pods (which keep
+// status.phase=Running until they exit) and pods without an assigned IP are
+// excluded. An empty filtered result returns ErrNoPodsAvailable so that the
+// cluster engine retries the join instead of bootstrapping a standalone cluster.
 func (d *Discovery) DiscoverPeers() ([]string, error) {
 	if !d.initialized.Load() {
 		return nil, discovery.ErrNotInitialized
@@ -155,26 +172,43 @@ func (d *Discovery) DiscoverPeers() ([]string, error) {
 
 	addresses := goset.NewSet[string]()
 
-MainLoop:
 	for _, pod := range pods.Items {
-		// If there is a Ready condition available, we need that to be true.
-		// If no ready condition is set, then we accept this pod regardless.
-		for _, condition := range pod.Status.Conditions {
-			if condition.Type == corev1.PodReady && condition.Status != corev1.ConditionTrue {
-				continue MainLoop
-			}
+		// Terminating pods keep status.phase=Running until their containers exit;
+		// skip them so rolling updates do not feed dying IPs to memberlist.
+		if pod.DeletionTimestamp != nil {
+			continue
 		}
 
-		for _, container := range pod.Spec.Containers {
-			for _, port := range container.Ports {
-				if port.Name == d.config.DiscoveryPortName {
-					addresses.Add(net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(int(port.ContainerPort))))
-					continue MainLoop
-				}
+		// A Running pod may not have an IP assigned yet in the API server's view.
+		if pod.Status.PodIP == "" {
+			continue
+		}
+
+		if port, ok := discoveryPort(&pod, d.config.DiscoveryPortName); ok {
+			addresses.Add(net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(int(port))))
+		}
+	}
+
+	if addresses.Cardinality() == 0 {
+		return nil, ErrNoPodsAvailable
+	}
+
+	return addresses.ToSlice(), nil
+}
+
+// discoveryPort returns the container port named portName from the pod spec.
+// Kubernetes enforces that port names are unique across all containers of a pod,
+// so at most one match exists.
+func discoveryPort(pod *corev1.Pod, portName string) (int32, bool) {
+	for _, container := range pod.Spec.Containers {
+		for _, port := range container.Ports {
+			if port.Name == portName {
+				return port.ContainerPort, true
 			}
 		}
 	}
-	return addresses.ToSlice(), nil
+
+	return 0, false
 }
 
 // Close closes the provider

--- a/discovery/kubernetes/discovery_test.go
+++ b/discovery/kubernetes/discovery_test.go
@@ -341,83 +341,123 @@ func TestDiscoverPeersFailures(t *testing.T) {
 		require.Nil(t, peers)
 	})
 
-	t.Run("filters out non ready pods", func(t *testing.T) {
-		config := newConfig()
-		ns := "test"
-
-		labels := map[string]string{
-			"app.kubernetes.io/name": "test",
-		}
-
-		pods := []runtime.Object{
-			&corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pending-pod",
-					Namespace: ns,
-					Labels:    labels,
-				},
-				Status: corev1.PodStatus{
-					Phase: corev1.PodPending,
-					PodIP: "10.0.0.30",
+	newPod := func(name, ip string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "test",
+				Labels: map[string]string{
+					"app.kubernetes.io/name": "test",
 				},
 			},
-			&corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "not-ready",
-					Namespace: ns,
-					Labels:    labels,
-				},
-				Status: corev1.PodStatus{
-					Phase: corev1.PodRunning,
-					PodIP: "10.0.0.31",
-					Conditions: []corev1.PodCondition{
-						{
-							Type:   corev1.PodReady,
-							Status: corev1.ConditionFalse,
-						},
-					},
-				},
-			},
-			&corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "no-discovery-port",
-					Namespace: ns,
-					Labels:    labels,
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Ports: []corev1.ContainerPort{
-								{
-									Name:          "metrics",
-									ContainerPort: 9090,
-								},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          gossipPortName,
+								ContainerPort: 3379,
+							},
+							{
+								Name:          peersPortName,
+								ContainerPort: 3380,
+							},
+							{
+								Name:          remotingPortName,
+								ContainerPort: 9000,
 							},
 						},
 					},
 				},
-				Status: corev1.PodStatus{
-					Phase: corev1.PodRunning,
-					PodIP: "10.0.0.32",
-					Conditions: []corev1.PodCondition{
-						{
-							Type:   corev1.PodReady,
-							Status: corev1.ConditionTrue,
-						},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				PodIP: ip,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionTrue,
 					},
 				},
 			},
 		}
+	}
 
-		client := testclient.NewClientset(pods...)
+	t.Run("includes not ready pods", func(t *testing.T) {
+		// On a cold start every pod is Running but not yet Ready. Discovery must
+		// still return them, otherwise no cluster can ever form.
+		notReady := newPod("not-ready", "10.0.0.31")
+		notReady.Status.Conditions = []corev1.PodCondition{
+			{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionFalse,
+			},
+		}
+
+		client := testclient.NewClientset(notReady)
 		provider := Discovery{
 			client:      client,
 			initialized: atomic.NewBool(true),
-			config:      config,
+			config:      newConfig(),
 		}
 
 		peers, err := provider.DiscoverPeers()
 		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"10.0.0.31:3379"}, peers)
+	})
+
+	t.Run("excludes terminating pods", func(t *testing.T) {
+		terminating := newPod("terminating", "10.0.0.32")
+		terminating.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+		terminating.Finalizers = []string{"goakt.io/test"}
+
+		client := testclient.NewClientset(newPod("healthy", "10.0.0.33"), terminating)
+		provider := Discovery{
+			client:      client,
+			initialized: atomic.NewBool(true),
+			config:      newConfig(),
+		}
+
+		peers, err := provider.DiscoverPeers()
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"10.0.0.33:3379"}, peers)
+	})
+
+	t.Run("excludes pods without an IP", func(t *testing.T) {
+		client := testclient.NewClientset(newPod("healthy", "10.0.0.34"), newPod("no-ip", ""))
+		provider := Discovery{
+			client:      client,
+			initialized: atomic.NewBool(true),
+			config:      newConfig(),
+		}
+
+		peers, err := provider.DiscoverPeers()
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"10.0.0.34:3379"}, peers)
+	})
+
+	t.Run("empty result is a retryable error", func(t *testing.T) {
+		// The calling pod must at minimum see itself once it is Running, so an
+		// empty result means API status lag and must feed the join retry loop
+		// instead of silently bootstrapping a standalone cluster.
+		noPort := newPod("no-discovery-port", "10.0.0.35")
+		noPort.Spec.Containers[0].Ports = []corev1.ContainerPort{
+			{
+				Name:          "metrics",
+				ContainerPort: 9090,
+			},
+		}
+
+		client := testclient.NewClientset(noPort)
+		provider := Discovery{
+			client:      client,
+			initialized: atomic.NewBool(true),
+			config:      newConfig(),
+		}
+
+		peers, err := provider.DiscoverPeers()
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrNoPodsAvailable)
 		assert.Empty(t, peers)
 	})
 }

--- a/docs/clustering/service-discovery.mdx
+++ b/docs/clustering/service-discovery.mdx
@@ -45,6 +45,27 @@ type Provider interface {
 
 Each provider has its own config type. See the package for constructors and options.
 
+### Kubernetes
+
+The Kubernetes provider lists pods through the Kubernetes API, matching the configured labels and `status.phase=Running`. Pods do not need to be Ready to be discovered: on a cold start no pod is Ready until its actor system has joined the cluster, so readiness cannot gate discovery. Terminating pods and pods without an assigned IP are excluded, and an empty result is treated as a retryable error so that simultaneously starting replicas keep retrying until they see each other.
+
+```go
+import "github.com/tochemey/goakt/v4/discovery/kubernetes"
+
+config := &kubernetes.Config{
+    Namespace:         "default",
+    DiscoveryPortName: "gossip",
+    RemotingPortName:  "remoting",
+    PeersPortName:     "cluster",
+    PodLabels:         map[string]string{"app": "goakt"},
+}
+provider := kubernetes.NewDiscovery(config)
+```
+
+<Tip>
+For production deployments, set `WithMinimumPeersQuorum` to a majority of the replica count (e.g. 2 for 3 replicas). With the default quorum of 1, a node that cannot reach its peers is allowed to operate as a single-node cluster.
+</Tip>
+
 ### Self-managed (zero config)
 
 The self-managed provider uses UDP broadcast for peer discovery. No third-party services or peer IPs are required; nodes on the same LAN discover each other automatically.


### PR DESCRIPTION
closes #1265 