### PR TITLE
fix(actor): prevent duplicate actors on concurrent same-name spawns

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
   pull_request:
+    # ready_for_review is not a default activity type: list it (plus the
+    # defaults) so marking a draft PR ready also starts a run.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
 

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -2,7 +2,7 @@ name: "Lint PR"
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, edited, reopened, synchronize, ready_for_review]
 
 permissions: {}
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,10 @@ name: pr
 
 on:
   pull_request:
+    # ready_for_review is not a default activity type: without it, marking a
+    # draft PR ready does not start a run, leaving the draft-gated lint/test
+    # jobs skipped until the next push.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### 🔧 Fixes
+
+- **Concurrent same-name spawns no longer create duplicate actors** ([#1277](https://github.com/Tochemey/goakt/pull/1277)). Goroutines racing `Spawn`, `SpawnNamedFromFunc`, `SpawnChild`, or the local `SpawnSingleton` path with the same name could each create a live actor instance: the tree-insertion conflict was swallowed, so the losing caller received an unsupervised orphan whose later shutdown detached the canonical actor from the tree (both instances share the same ID). Local spawns of one identity are now serialized through a singleflight group keyed by the actor address, so a name yields exactly one PID under concurrency; racing callers coalesce onto the in-flight spawn and share its result. The wait is context-aware — a caller whose context expires stops waiting with its own context error — and a waiter that inherits a cancellation caused by the winning caller's context while its own is still live retries once. As a safety net, `completeSpawn` now detects a duplicate tree insertion, returns the canonical instance, undoes the actors-counter bump, and logs a warning instead of handing back an orphan.
+- **Singleton idempotent success resolves the PID from the confirmed registry address** ([#1277](https://github.com/Tochemey/goakt/pull/1277)). When `SpawnSingleton` found the name already bound to the singleton it intended to create, it re-resolved the PID with a second registry lookup that could momentarily miss the record and surface `ErrActorNotFound` from a creation call. The PID is now resolved from the address read while confirming the conflict (preferring a live local instance when the singleton is hosted on the calling node), and the idempotent path never surfaces `ErrActorNotFound`.
+- **Leader-delegated singleton spawns stay retryable during membership churn** ([#1277](https://github.com/Tochemey/goakt/pull/1277)). A spawn delegated to the cluster leader that failed because no leader was elected yet (`ErrLeaderNotFound`), the cluster engine was not running, or no member carried the requested role was serialized back as `CODE_INTERNAL_ERROR`, which the delegating node treats as terminal. These transient membership conditions now map to `CODE_UNAVAILABLE`, which the delegating node's retry loop recognizes as retryable within its configured budget — so a `SpawnSingleton` issued during a rolling restart retries until the cluster settles instead of failing permanently.
+
 ## v4.4.1 - 2026-07-20
 
 ### ✨ Features

--- a/actor/actor_system.go
+++ b/actor/actor_system.go
@@ -799,6 +799,10 @@ type ActorSystem interface {
 	// record to the cluster. On publication failure the actor is stopped so
 	// a failed spawn leaves nothing behind, and the error is returned.
 	completeSpawn(ctx context.Context, parent, pid *PID) (*PID, error)
+	// runSpawnActivation serializes concurrent local spawns sharing the same
+	// actor identity (key) so a name yields exactly one PID under concurrency.
+	// The wait is bounded by ctx; see the implementation for the full contract.
+	runSpawnActivation(ctx context.Context, key string, fn func() (*PID, error)) (*PID, error)
 	// getCluster returns the cluster engine
 	getCluster() cluster.Cluster
 	// tree returns the actors tree
@@ -1028,9 +1032,14 @@ type actorSystem struct {
 	remoteSenderAddresses *xsync.Map[string, *address.Address]
 	grainBarrier          *grainActivationBarrier
 	grainActivation       singleflight.Group
-	evictionStrategy      *EvictionStrategy
-	evictionInterval      time.Duration
-	evictionStopSig       chan types.Unit
+	// spawnActivation serializes concurrent local spawns of the same actor
+	// identity so that only one PID is ever created and inserted into the tree,
+	// keeping name-based spawns (including singletons) idempotent under
+	// concurrency. Keyed by the actor address string (pid.ID()).
+	spawnActivation  singleflight.Group
+	evictionStrategy *EvictionStrategy
+	evictionInterval time.Duration
+	evictionStopSig  chan types.Unit
 
 	metricProvider *metric.Provider
 	// relocationMetric holds the synchronous relocation instruments. It is nil
@@ -1913,7 +1922,7 @@ func (x *actorSystem) Actors(ctx context.Context, timeout time.Duration) ([]*PID
 	return pids, nil
 }
 
-// PeerAddress returns the actor system address known in the cluster. That address is used by other nodesMap to communicate with the actor system.
+// PeersAddress returns the actor system address known in the cluster. That address is used by other nodesMap to communicate with the actor system.
 // This address is empty when cluster mode is not activated
 func (x *actorSystem) PeersAddress() string {
 	if x.clusterEnabled.Load() {
@@ -2466,7 +2475,30 @@ func (x *actorSystem) completeSpawn(ctx context.Context, parent, pid *PID) (*PID
 		x.increaseActorsCounter()
 	}
 
-	_ = x.actors.addNode(parent, pid)
+	if err := x.actors.addNode(parent, pid); err != nil {
+		if errors.Is(err, errNodeAlreadyExists) {
+			if node, ok := x.actors.node(pid.ID()); ok {
+				if canonical := node.value(); canonical != nil && canonical != pid {
+					// A concurrent spawn already registered this identity: hand back the
+					// canonical instance and undo the counter bump above, which accounted
+					// for a node that was never inserted. The duplicate is deliberately
+					// NOT shut down: freeWatchers/freeChildren/freeWatchees resolve tree
+					// state by the shared pid.ID(), so stopping the duplicate would
+					// detach the canonical instance from the tree.
+					if !pid.isStateSet(systemState) {
+						x.decreaseActorsCounter()
+					}
+					// This path should be unreachable while every spawn entry point is
+					// serialized through runSpawnActivation; log loudly so an unserialized
+					// caller (and the intentionally leaked duplicate) does not go unnoticed.
+					x.logger.Warnf("duplicate spawn detected for actor=%s: returning the canonical instance; the duplicate instance is left unmanaged", pid.Name())
+					return canonical, nil
+				}
+			}
+		}
+		// Same-instance re-adds and other insertion failures keep the historical
+		// behavior: proceed with supervision and cluster publication.
+	}
 	x.actors.addWatcher(pid, x.deathWatch)
 
 	if err := x.putActorOnCluster(ctx, pid); err != nil {

--- a/actor/actor_system_test.go
+++ b/actor/actor_system_test.go
@@ -6369,6 +6369,12 @@ func TestActorSystemRun(t *testing.T) {
 	// Ensure the signal handling goroutine is ready.
 	pause.For(50 * time.Millisecond)
 
+	// os.Process.Signal (unlike syscall.Kill) compiles on Windows, where this
+	// test is skipped at runtime.
+	proc, err := os.FindProcess(os.Getpid())
+	require.NoError(t, err)
+	require.NoError(t, proc.Signal(syscall.SIGINT))
+
 	require.Eventually(t, func() bool {
 		select {
 		case <-done:

--- a/actor/actor_system_test.go
+++ b/actor/actor_system_test.go
@@ -6369,8 +6369,6 @@ func TestActorSystemRun(t *testing.T) {
 	// Ensure the signal handling goroutine is ready.
 	pause.For(50 * time.Millisecond)
 
-	require.NoError(t, syscall.Kill(os.Getpid(), syscall.SIGINT))
-
 	require.Eventually(t, func() bool {
 		select {
 		case <-done:

--- a/actor/cluster_singleton_test.go
+++ b/actor/cluster_singleton_test.go
@@ -29,6 +29,7 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -789,7 +790,7 @@ func TestSpawnSingletonRetryBehavior(t *testing.T) {
 			Address:   "goakt://test@127.0.0.1:0/singleton",
 			Type:      "actor.mockactor",
 			Singleton: &internalpb.SingletonSpec{},
-		}, nil).Times(2)
+		}, nil).Once()
 
 		_, err := system.SpawnSingleton(
 			ctx,
@@ -821,7 +822,8 @@ func TestSpawnSingletonRetryBehavior(t *testing.T) {
 				Coordinator:  true,
 			},
 		}, nil).Once()
-		clusterMock.EXPECT().ActorExists(mock.Anything, "singleton").Return(false, context.Canceled).Once()
+		// No ActorExists expectation: an already-canceled context is rejected by
+		// runSpawnActivation before the spawn attempt reaches the cluster.
 
 		_, err := system.SpawnSingleton(
 			ctx,
@@ -898,7 +900,7 @@ func TestSpawnSingletonRetryBehavior(t *testing.T) {
 			Address:   "goakt://test@127.0.0.1:0/singleton",
 			Type:      "actor.mockactor",
 			Singleton: &internalpb.SingletonSpec{},
-		}, nil).Times(2)
+		}, nil).Once()
 
 		_, err := system.SpawnSingleton(
 			ctx,
@@ -962,7 +964,7 @@ func TestSpawnSingletonRetryBehavior(t *testing.T) {
 			Address:   "goakt://test@127.0.0.1:0/singleton",
 			Type:      "actor.mockactor",
 			Singleton: &internalpb.SingletonSpec{},
-		}, nil).Times(2)
+		}, nil).Once()
 
 		leader := &cluster.Peer{
 			Host:         "127.0.0.1",
@@ -1031,7 +1033,7 @@ func TestSpawnSingletonRetryBehavior(t *testing.T) {
 			Address:   "goakt://test@127.0.0.1:0/singleton",
 			Type:      "actor.mockactor",
 			Singleton: &internalpb.SingletonSpec{},
-		}, nil).Times(2)
+		}, nil).Once()
 
 		_, err := system.SpawnSingleton(
 			ctx,
@@ -1042,6 +1044,98 @@ func TestSpawnSingletonRetryBehavior(t *testing.T) {
 			WithSingletonSpawnTimeout(time.Second),
 		)
 		require.NoError(t, err)
+	})
+
+	t.Run("idempotent success resolves the confirmed address without a second lookup", func(t *testing.T) {
+		ctx := context.Background()
+		clusterMock := mockcluster.NewCluster(t)
+		remotingMock := mockremote.NewClient(t)
+		system := MockSingletonClusterReadyActorSystem(t)
+		system.remoting = remotingMock
+
+		system.locker.Lock()
+		system.cluster = clusterMock
+		system.locker.Unlock()
+
+		// Local coordinator: the local spawn reports the name is already taken.
+		clusterMock.EXPECT().Members(mock.Anything).Return([]*cluster.Peer{
+			{
+				Host:         system.clusterNode.Host,
+				PeersPort:    system.clusterNode.PeersPort,
+				RemotingPort: system.clusterNode.RemotingPort,
+				Coordinator:  true,
+			},
+		}, nil).Once()
+		clusterMock.EXPECT().ActorExists(mock.Anything, "singleton").Return(true, nil).Once()
+
+		// The conflict handler confirms the name is bound to our singleton with a single
+		// GetActor call. The PID must then be resolved from this record's address WITHOUT a
+		// second lookup — the .Once() below fails if the old ActorOf re-resolution returns.
+		// This is the regression guard: a creation call must never leak ErrActorNotFound
+		// on the idempotent path just because a second read momentarily 404s.
+		const confirmedAddr = "goakt://test@127.0.0.1:9000/singleton"
+		clusterMock.EXPECT().GetActor(mock.Anything, "singleton").Return(&internalpb.Actor{
+			Address:   confirmedAddr,
+			Type:      "actor.mockactor",
+			Singleton: &internalpb.SingletonSpec{},
+		}, nil).Once()
+
+		pid, err := system.SpawnSingleton(
+			ctx,
+			"singleton",
+			NewMockActor(),
+			WithSingletonSpawnRetries(2),
+			WithSingletonSpawnWaitInterval(time.Millisecond),
+			WithSingletonSpawnTimeout(time.Second),
+		)
+		require.NoError(t, err)
+		require.NotErrorIs(t, err, gerrors.ErrActorNotFound)
+		require.NotNil(t, pid)
+		require.True(t, pid.IsRemote())
+		require.Equal(t, confirmedAddr, pid.Path().String())
+	})
+
+	t.Run("never returns ErrActorNotFound to the caller on the idempotent path", func(t *testing.T) {
+		ctx := context.Background()
+		clusterMock := mockcluster.NewCluster(t)
+		system := MockSingletonClusterReadyActorSystem(t)
+
+		system.locker.Lock()
+		system.cluster = clusterMock
+		system.locker.Unlock()
+
+		// Local coordinator: the local spawn reports the name is already taken.
+		clusterMock.EXPECT().Members(mock.Anything).Return([]*cluster.Peer{
+			{
+				Host:         system.clusterNode.Host,
+				PeersPort:    system.clusterNode.PeersPort,
+				RemotingPort: system.clusterNode.RemotingPort,
+				Coordinator:  true,
+			},
+		}, nil).Once()
+		clusterMock.EXPECT().ActorExists(mock.Anything, "singleton").Return(true, nil).Once()
+
+		// Confirmation succeeds (it is our singleton) but the record carries no address,
+		// which forces the by-name fallback resolution...
+		clusterMock.EXPECT().GetActor(mock.Anything, "singleton").Return(&internalpb.Actor{
+			Address:   "",
+			Type:      "actor.mockactor",
+			Singleton: &internalpb.SingletonSpec{},
+		}, nil).Once()
+		// ...which momentarily 404s while the registry record propagates.
+		clusterMock.EXPECT().GetActor(mock.Anything, "singleton").Return(nil, cluster.ErrActorNotFound).Once()
+
+		_, err := system.SpawnSingleton(
+			ctx,
+			"singleton",
+			NewMockActor(),
+			WithSingletonSpawnRetries(2),
+			WithSingletonSpawnWaitInterval(time.Millisecond),
+			WithSingletonSpawnTimeout(time.Second),
+		)
+		require.Error(t, err)
+		// A creation call must never tell the caller the actor it just created was not found.
+		require.NotErrorIs(t, err, gerrors.ErrActorNotFound)
 	})
 
 	t.Run("retries when GetActor returns retryable error during name conflict", func(t *testing.T) {
@@ -1072,7 +1166,7 @@ func TestSpawnSingletonRetryBehavior(t *testing.T) {
 			Address:   "goakt://test@127.0.0.1:0/singleton",
 			Type:      "actor.mockactor",
 			Singleton: &internalpb.SingletonSpec{},
-		}, nil).Times(2)
+		}, nil).Once()
 
 		_, err := system.SpawnSingleton(
 			ctx,
@@ -1509,6 +1603,95 @@ func TestSpawnSingletonRetryBehavior(t *testing.T) {
 	})
 }
 
+// TestResolveExistingSingleton covers the idempotent-success resolution helper used by
+// retrySpawnSingleton: it must prefer a live local PID, otherwise build a remote PID from
+// the address confirmed during conflict handling, and only fall back to a by-name lookup
+// when no address was captured.
+func TestResolveExistingSingleton(t *testing.T) {
+	t.Run("prefers a live local PID over the confirmed address", func(t *testing.T) {
+		ctx := context.Background()
+		sys, err := NewActorSystem("test", WithLogger(log.DiscardLogger))
+		require.NoError(t, err)
+		require.NoError(t, sys.Start(ctx))
+		t.Cleanup(func() {
+			require.NoError(t, sys.Stop(ctx))
+		})
+
+		actorSys := sys.(*actorSystem)
+		const actorName = "local-singleton"
+		localPID, err := actorSys.configPID(ctx, actorName, NewMockActor(), WithLongLived())
+		require.NoError(t, err)
+		require.NoError(t, actorSys.tree().addNode(actorSys.getUserGuardian(), localPID))
+
+		// A remote address is supplied, but the singleton is hosted locally: the live local
+		// PID must win so we never hand back a remote proxy to ourselves.
+		got, err := actorSys.resolveExistingSingleton(ctx, actorName, "goakt://test@127.0.0.1:9000/local-singleton")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.False(t, got.IsRemote())
+		require.Same(t, localPID, got)
+	})
+
+	t.Run("builds a remote PID from the confirmed address when not hosted locally", func(t *testing.T) {
+		ctx := context.Background()
+		remotingMock := mockremote.NewClient(t)
+		system := MockSingletonClusterReadyActorSystem(t)
+		system.remoting = remotingMock
+
+		const confirmedAddr = "goakt://test@127.0.0.1:9000/remote-singleton"
+		got, err := system.resolveExistingSingleton(ctx, "remote-singleton", confirmedAddr)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.True(t, got.IsRemote())
+		require.Equal(t, confirmedAddr, got.Path().String())
+	})
+
+	t.Run("falls back to ActorOf when no address was captured", func(t *testing.T) {
+		ctx := context.Background()
+		clusterMock := mockcluster.NewCluster(t)
+		remotingMock := mockremote.NewClient(t)
+		system := MockSingletonClusterReadyActorSystem(t)
+		system.remoting = remotingMock
+
+		system.locker.Lock()
+		system.cluster = clusterMock
+		system.locker.Unlock()
+
+		const resolvedAddr = "goakt://test@127.0.0.1:9000/fallback-singleton"
+		clusterMock.EXPECT().GetActor(mock.Anything, "fallback-singleton").Return(&internalpb.Actor{
+			Address:   resolvedAddr,
+			Type:      "actor.mockactor",
+			Singleton: &internalpb.SingletonSpec{},
+		}, nil).Once()
+
+		got, err := system.resolveExistingSingleton(ctx, "fallback-singleton", "")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.True(t, got.IsRemote())
+		require.Equal(t, resolvedAddr, got.Path().String())
+	})
+
+	t.Run("never surfaces ErrActorNotFound when the fallback lookup 404s", func(t *testing.T) {
+		ctx := context.Background()
+		clusterMock := mockcluster.NewCluster(t)
+		system := MockSingletonClusterReadyActorSystem(t)
+
+		system.locker.Lock()
+		system.cluster = clusterMock
+		system.locker.Unlock()
+
+		// No confirmed address, and the by-name fallback cannot see the record yet.
+		clusterMock.EXPECT().GetActor(mock.Anything, "ghost-singleton").Return(nil, cluster.ErrActorNotFound).Once()
+
+		got, err := system.resolveExistingSingleton(ctx, "ghost-singleton", "")
+		require.Error(t, err)
+		require.Nil(t, got)
+		// The singleton was confirmed to exist upstream, so a creation call must never
+		// leak ErrActorNotFound to the caller.
+		require.NotErrorIs(t, err, gerrors.ErrActorNotFound)
+	})
+}
+
 func TestShouldRetrySpawnSingleton(t *testing.T) {
 	cases := []struct {
 		name string
@@ -1538,4 +1721,92 @@ func TestShouldRetrySpawnSingleton(t *testing.T) {
 			require.Equal(t, tc.want, shouldRetrySpawnSingleton(tc.err))
 		})
 	}
+}
+
+// TestConcurrentSpawnSingletonSingleInstance is an integration test that hammers
+// SpawnSingleton for the same name concurrently from every node in a real
+// (NATS-backed) cluster. It asserts the singleton converges to a single
+// instance: every call succeeds and resolves to the same address, exactly one
+// node hosts it locally, and it is resolvable cluster-wide from every node.
+func TestConcurrentSpawnSingletonSingleInstance(t *testing.T) {
+	ctx := context.TODO()
+	srv := startNatsServer(t)
+
+	cl1, sd1 := testNATs(t, srv.Addr().String())
+	require.NotNil(t, cl1)
+	cl2, sd2 := testNATs(t, srv.Addr().String())
+	require.NotNil(t, cl2)
+	cl3, sd3 := testNATs(t, srv.Addr().String())
+	require.NotNil(t, cl3)
+
+	// let the cluster settle
+	pause.For(time.Second)
+
+	systems := []ActorSystem{cl1, cl2, cl3}
+	const perNode = 5
+	total := len(systems) * perNode
+	name := "concurrent-singleton"
+
+	var (
+		wg   sync.WaitGroup
+		gate = make(chan struct{})
+		pids = make([]*PID, total)
+		errs = make([]error, total)
+	)
+
+	idx := 0
+	for _, sys := range systems {
+		for j := 0; j < perNode; j++ {
+			i := idx
+			s := sys
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-gate
+				pids[i], errs[i] = s.SpawnSingleton(ctx, name, NewMockActor())
+			}()
+			idx++
+		}
+	}
+	close(gate)
+	wg.Wait()
+
+	// every concurrent call succeeds and resolves to the same singleton address
+	var addr string
+	for i := 0; i < total; i++ {
+		require.NoErrorf(t, errs[i], "call %d failed", i)
+		require.NotNilf(t, pids[i], "call %d returned a nil pid", i)
+		if addr == "" {
+			addr = pids[i].ID()
+			continue
+		}
+		require.Equalf(t, addr, pids[i].ID(), "call %d resolved to a different address", i)
+	}
+
+	// exactly one node hosts the singleton locally (a single live instance)
+	localHosts := 0
+	for _, sys := range systems {
+		if node, ok := sys.tree().nodeByName(name); ok {
+			if pid := node.value(); pid != nil && pid.IsRunning() {
+				localHosts++
+			}
+		}
+	}
+	require.Equal(t, 1, localHosts, "singleton must be hosted on exactly one node")
+
+	// resolvable to the same address from every node
+	for _, sys := range systems {
+		pid, err := sys.ActorOf(ctx, name)
+		require.NoError(t, err)
+		require.NotNil(t, pid)
+		require.Equal(t, addr, pid.ID())
+	}
+
+	require.NoError(t, cl3.Stop(ctx))
+	require.NoError(t, sd3.Close())
+	require.NoError(t, cl1.Stop(ctx))
+	require.NoError(t, sd1.Close())
+	require.NoError(t, cl2.Stop(ctx))
+	require.NoError(t, sd2.Close())
+	srv.Shutdown()
 }

--- a/actor/fixtures_test.go
+++ b/actor/fixtures_test.go
@@ -87,6 +87,22 @@ func setupReSpawnClusterTest(t *testing.T) (*mockcluster.Cluster, *mocksremote.C
 	return clusterMock, remotingMock, system
 }
 
+// countingActor counts how many distinct instances actually start, so a test can
+// assert that racing spawns produced a single live actor. Instances share the
+// counter through a pointer.
+type countingActor struct {
+	starts *atomic.Int64
+}
+
+var _ Actor = (*countingActor)(nil)
+
+func (a *countingActor) PreStart(*Context) error {
+	a.starts.Add(1)
+	return nil
+}
+func (a *countingActor) PostStop(*Context) error { return nil }
+func (a *countingActor) Receive(*ReceiveContext) {}
+
 type MockSubscriber struct {
 	counter *atomic.Int64
 }

--- a/actor/pid.go
+++ b/actor/pid.go
@@ -3348,33 +3348,41 @@ func (pid *PID) spawnChildLocal(ctx context.Context, name string, actor Actor, c
 		return existing, nil
 	}
 
-	if config.dependencies != nil {
-		_ = pid.ActorSystem().Inject(config.dependencies...)
-	}
+	// Serialize concurrent spawns of the same child so only one PID is created
+	// and inserted; concurrent callers coalesce onto the winner and share it.
+	return pid.actorSystem.runSpawnActivation(ctx, childAddress.String(), func() (*PID, error) {
+		if existing, ok := pid.findRunningChild(tree, childAddress.String()); ok {
+			return existing, nil
+		}
 
-	cid, err := newPID(
-		ctx,
-		childAddress,
-		actor,
-		pid.buildChildOptions(config)...,
-	)
-	if err != nil {
-		return nil, err
-	}
+		if config.dependencies != nil {
+			_ = pid.ActorSystem().Inject(config.dependencies...)
+		}
 
-	// attach the child to the tree, supervise it and publish it to the cluster
-	if _, err := pid.ActorSystem().completeSpawn(ctx, pid, cid); err != nil {
-		return nil, err
-	}
+		cid, err := newPID(
+			ctx,
+			childAddress,
+			actor,
+			pid.buildChildOptions(config)...,
+		)
+		if err != nil {
+			return nil, err
+		}
 
-	// the event is published only after successful cluster publication, so it
-	// means durable creation
-	eventsStream := pid.eventsStream
-	if eventsStream != nil {
-		eventsStream.Publish(eventsTopic, NewActorChildCreated(cid.Path(), pid.Path()))
-	}
+		// attach the child to the tree, supervise it and publish it to the cluster
+		if _, err := pid.ActorSystem().completeSpawn(ctx, pid, cid); err != nil {
+			return nil, err
+		}
 
-	return cid, nil
+		// the event is published only after successful cluster publication, so it
+		// means durable creation
+		eventsStream := pid.eventsStream
+		if eventsStream != nil {
+			eventsStream.Publish(eventsTopic, NewActorChildCreated(cid.Path(), pid.Path()))
+		}
+
+		return cid, nil
+	})
 }
 
 // findRunningChild returns the child PID registered at childAddress in tree

--- a/actor/pid_test.go
+++ b/actor/pid_test.go
@@ -2858,6 +2858,123 @@ func TestSpawnChild(t *testing.T) {
 		pause.For(time.Second)
 		assert.NoError(t, actorSystem.Stop(ctx))
 	})
+	t.Run("With dependencies injected into the actor system", func(t *testing.T) {
+		ctx := context.TODO()
+		host := "127.0.0.1"
+		ports := dynaport.Get(1)
+
+		testSystem, err := NewActorSystem("testSys",
+			WithRemote(remote.NewConfig(host, ports[0])),
+			WithLogger(log.DiscardLogger))
+
+		require.NoError(t, err)
+		require.NotNil(t, testSystem)
+
+		require.NoError(t, testSystem.Start(ctx))
+
+		pause.For(time.Second)
+
+		// create the parent actor
+		parent, err := testSystem.Spawn(ctx, "Parent", NewMockSupervisor())
+		require.NoError(t, err)
+		assert.NotNil(t, parent)
+
+		// the dependency type is not known to the actor system yet
+		dependency := NewMockDependency("child-dep", "user", "email")
+		sys := testSystem.(*actorSystem)
+		require.False(t, sys.registry.Exists(dependency))
+
+		// create the child actor with a dependency
+		child, err := parent.SpawnChild(ctx, "SpawnChild", NewMockSupervised(), WithDependencies(dependency))
+		require.NoError(t, err)
+		require.NotNil(t, child)
+
+		pause.For(time.Second)
+
+		// spawning the child injected the dependency type into the actor system registry
+		require.True(t, sys.registry.Exists(dependency))
+
+		// and the child carries the dependency
+		deps := child.Dependencies()
+		require.Len(t, deps, 1)
+		require.Equal(t, dependency.ID(), deps[0].ID())
+
+		//stop the actor
+		require.NoError(t, parent.Shutdown(ctx))
+		pause.For(time.Second)
+		assert.NoError(t, testSystem.Stop(ctx))
+	})
+	t.Run("With existing running child found after waiting on an in-flight spawn", func(t *testing.T) {
+		ctx := context.TODO()
+		host := "127.0.0.1"
+		ports := dynaport.Get(1)
+
+		testSystem, err := NewActorSystem("testSys",
+			WithRemote(remote.NewConfig(host, ports[0])),
+			WithLogger(log.DiscardLogger))
+
+		require.NoError(t, err)
+		require.NotNil(t, testSystem)
+
+		require.NoError(t, testSystem.Start(ctx))
+
+		pause.For(time.Second)
+
+		// create the parent actor
+		parent, err := testSystem.Spawn(ctx, "Parent", NewMockSupervisor())
+		require.NoError(t, err)
+		assert.NotNil(t, parent)
+
+		sys := testSystem.(*actorSystem)
+		childAddress := parent.childAddress("child")
+
+		// hold the spawn activation for the child's identity with a flight that
+		// only completes with the winner's context error
+		winnerCtx, winnerCancel := context.WithCancel(context.Background())
+		entered := make(chan struct{})
+		winnerDone := make(chan struct{})
+		go func() {
+			defer close(winnerDone)
+			_, _ = sys.runSpawnActivation(winnerCtx, childAddress.String(), func() (*PID, error) {
+				close(entered)
+				<-winnerCtx.Done()
+				return nil, winnerCtx.Err()
+			})
+		}()
+		<-entered
+
+		// SpawnChild passes the pre-activation existence check (no child yet)
+		// and coalesces onto the held activation as a waiter
+		var child *PID
+		var spawnErr error
+		spawned := make(chan struct{})
+		go func() {
+			defer close(spawned)
+			child, spawnErr = parent.SpawnChild(context.Background(), "child", NewMockSupervised())
+		}()
+		pause.For(500 * time.Millisecond) // let the waiter join the flight
+
+		// materialize the child out-of-band while the activation is still held
+		existing, err := newPID(ctx, childAddress, NewMockSupervised(), parent.buildChildOptions(newSpawnConfig())...)
+		require.NoError(t, err)
+		_, err = sys.completeSpawn(ctx, parent, existing)
+		require.NoError(t, err)
+
+		// abort the winner: the waiter inherits the shared cancellation, retries
+		// once, and the retry finds the already-running child instead of
+		// creating a duplicate
+		winnerCancel()
+		<-spawned
+		<-winnerDone
+
+		require.NoError(t, spawnErr)
+		require.Same(t, existing, child)
+
+		//stop the actor
+		require.NoError(t, parent.Shutdown(ctx))
+		pause.For(time.Second)
+		assert.NoError(t, testSystem.Stop(ctx))
+	})
 }
 func TestPoisonPill(t *testing.T) {
 	ctx := context.TODO()

--- a/actor/pid_tree.go
+++ b/actor/pid_tree.go
@@ -28,6 +28,11 @@ import (
 	"sync/atomic"
 )
 
+// errNodeAlreadyExists reports that a PID with the same ID is already
+// registered in the tree. completeSpawn relies on this sentinel to detect a
+// duplicate insertion and return the canonical instance instead.
+var errNodeAlreadyExists = errors.New("pid already exists")
+
 // pidNode represents a node in the PID tree.
 // Most fields are protected by the owning tree's mutex.
 // The pid field uses an atomic pointer because pidNode references may be
@@ -156,7 +161,7 @@ func (x *tree) addNodeLocked(parent, pid *PID) error {
 
 	id := pid.ID()
 	if _, exists := x.pids[id]; exists {
-		return errors.New("pid already exists")
+		return errNodeAlreadyExists
 	}
 
 	parentID := parent.ID()

--- a/actor/remote_server.go
+++ b/actor/remote_server.go
@@ -79,6 +79,33 @@ func toProtoError(code internalpb.Code, err error) *internalpb.Error {
 	}
 }
 
+// spawnErrorToProto maps a spawn failure to the proto error returned to a remote
+// spawn caller (remoteSpawnHandler).
+//
+// Transient cluster-membership conditions — quorum failures, no leader elected
+// yet, the cluster engine not (yet) running, or no members carrying the requested
+// role — are serialized as CODE_UNAVAILABLE. The delegating caller decodes that
+// code into ErrRemoteSendFailure, which its singleton retry loop
+// (shouldRetrySpawnSingleton) recognizes as retryable. Serializing them as
+// CODE_INTERNAL_ERROR instead would flatten them into an opaque, terminal error,
+// making a SpawnSingleton delegated during membership churn (e.g. a rolling
+// restart) fail permanently rather than retry within its configured budget.
+func spawnErrorToProto(err error) *internalpb.Error {
+	switch {
+	case errors.Is(err, gerrors.ErrActorAlreadyExists),
+		errors.Is(err, gerrors.ErrSingletonAlreadyExists): //nolint:staticcheck // old-version hosts still emit it during a rolling upgrade
+		return toProtoError(internalpb.Code_CODE_ALREADY_EXISTS, err)
+	case cluster.IsQuorumError(err):
+		return toProtoError(internalpb.Code_CODE_UNAVAILABLE, cluster.NormalizeQuorumError(err))
+	case errors.Is(err, gerrors.ErrLeaderNotFound),
+		errors.Is(err, cluster.ErrEngineNotRunning),
+		isNoRoleMembersError(err):
+		return toProtoError(internalpb.Code_CODE_UNAVAILABLE, err)
+	default:
+		return toProtoError(internalpb.Code_CODE_INTERNAL_ERROR, err)
+	}
+}
+
 // extractContextWithPropagator extracts metadata from the proto TCP context and applies
 // the configured ContextPropagator to enrich it with distributed tracing, auth, and other
 // cross-cutting concerns.
@@ -596,16 +623,6 @@ func (x *actorSystem) remoteSpawnHandler(ctx context.Context, conn inet.Connecti
 		return toProtoError(internalpb.Code_CODE_INTERNAL_ERROR, err), nil
 	}
 
-	wrapSpawnErr := func(err error) proto.Message {
-		if errors.Is(err, gerrors.ErrActorAlreadyExists) || errors.Is(err, gerrors.ErrSingletonAlreadyExists) { //nolint:staticcheck // old-version hosts still emit it during a rolling upgrade
-			return toProtoError(internalpb.Code_CODE_ALREADY_EXISTS, err)
-		}
-		if cluster.IsQuorumError(err) {
-			return toProtoError(internalpb.Code_CODE_UNAVAILABLE, cluster.NormalizeQuorumError(err))
-		}
-		return toProtoError(internalpb.Code_CODE_INTERNAL_ERROR, err)
-	}
-
 	if request.GetSingleton() != nil {
 		// Define singleton options
 		singletonOpts := []ClusterSingletonOption{
@@ -621,7 +638,7 @@ func (x *actorSystem) remoteSpawnHandler(ctx context.Context, conn inet.Connecti
 		pid, err := x.SpawnSingleton(ctx, request.GetActorName(), actor, singletonOpts...)
 		if err != nil {
 			logger.Errorf("failed to create actor (%s) on host=%s port=%d: %v (hint: check cluster quorum, singleton config)", request.GetActorName(), request.GetHost(), request.GetPort(), err)
-			return wrapSpawnErr(err), nil
+			return spawnErrorToProto(err), nil
 		}
 
 		logger.Debugf("actor=%s host=%s port=%d actor created successfully", request.GetActorName(), request.GetHost(), request.GetPort())
@@ -668,7 +685,7 @@ func (x *actorSystem) remoteSpawnHandler(ctx context.Context, conn inet.Connecti
 	pid, err := x.Spawn(ctx, request.GetActorName(), actor, opts...)
 	if err != nil {
 		logger.Errorf("failed to create actor (%s) on host=%s port=%d: %v (hint: verify actor type registered, check dependencies)", request.GetActorName(), request.GetHost(), request.GetPort(), err)
-		return wrapSpawnErr(err), nil
+		return spawnErrorToProto(err), nil
 	}
 
 	logger.Debugf("actor=%s created on host=%s port=%d", request.GetActorName(), request.GetHost(), request.GetPort())

--- a/actor/remote_server_test.go
+++ b/actor/remote_server_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/tochemey/goakt/v4/discovery"
 	gerrors "github.com/tochemey/goakt/v4/errors"
 	"github.com/tochemey/goakt/v4/internal/address"
+	"github.com/tochemey/goakt/v4/internal/cluster"
 	"github.com/tochemey/goakt/v4/internal/internalpb"
 	inet "github.com/tochemey/goakt/v4/internal/net"
 	"github.com/tochemey/goakt/v4/internal/pause"
@@ -2730,5 +2731,40 @@ func TestRelocateBatchHandler(t *testing.T) {
 		require.Len(t, response.GetFailures(), 1)
 		assert.Equal(t, "kind/lazy-fail", response.GetFailures()[0].GetId())
 		assert.True(t, response.GetFailures()[0].GetGrain())
+	})
+}
+
+// TestSpawnErrorToProto verifies the proto-code mapping applied to spawn failures
+// returned to remote (leader-delegated) spawn callers. Transient cluster-membership
+// conditions must be serialized as CODE_UNAVAILABLE — which the client decodes into
+// ErrRemoteSendFailure, a retryable error for shouldRetrySpawnSingleton — and never
+// flattened into CODE_INTERNAL_ERROR, which would make a SpawnSingleton delegated
+// during membership churn fail terminally.
+func TestSpawnErrorToProto(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		code internalpb.Code
+	}{
+		{name: "actor already exists", err: gerrors.ErrActorAlreadyExists, code: internalpb.Code_CODE_ALREADY_EXISTS},
+		{name: "singleton already exists", err: gerrors.ErrSingletonAlreadyExists, code: internalpb.Code_CODE_ALREADY_EXISTS}, //nolint:staticcheck // old-version hosts still emit it
+		{name: "write quorum", err: fmt.Errorf("spawn: %w", gerrors.ErrWriteQuorum), code: internalpb.Code_CODE_UNAVAILABLE},
+		{name: "leader not found", err: fmt.Errorf("spawn: %w", gerrors.ErrLeaderNotFound), code: internalpb.Code_CODE_UNAVAILABLE},
+		{name: "engine not running", err: fmt.Errorf("spawn: %w", cluster.ErrEngineNotRunning), code: internalpb.Code_CODE_UNAVAILABLE},
+		{name: "no role members", err: fmt.Errorf("spawn: %w", errNoRoleMembers{role: "worker"}), code: internalpb.Code_CODE_UNAVAILABLE},
+		{name: "arbitrary error", err: errors.New("boom"), code: internalpb.Code_CODE_INTERNAL_ERROR},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := spawnErrorToProto(tc.err)
+			require.Equal(t, tc.code, got.GetCode())
+			require.NotEmpty(t, got.GetMessage())
+		})
+	}
+
+	t.Run("quorum errors are normalized before serialization", func(t *testing.T) {
+		got := spawnErrorToProto(fmt.Errorf("spawn: %w", gerrors.ErrWriteQuorum))
+		require.Equal(t, gerrors.ErrWriteQuorum.Error(), got.GetMessage())
 	})
 }

--- a/actor/router.go
+++ b/actor/router.go
@@ -161,13 +161,13 @@ func (x *router) broadcast(ctx *ReceiveContext) {
 	case *GetRoutees:
 		x.handleGetRoutees(ctx)
 	case *AdjustRouterPoolSize:
-		x.handleAjustRouterPoolSize(ctx)
+		x.handleAdjustRouterPoolSize(ctx)
 	default:
 		ctx.Unhandled()
 	}
 }
 
-func (x *router) handleAjustRouterPoolSize(ctx *ReceiveContext) {
+func (x *router) handleAdjustRouterPoolSize(ctx *ReceiveContext) {
 	message := ctx.Message().(*AdjustRouterPoolSize)
 	delta := int(message.PoolSize())
 	if delta == 0 {

--- a/actor/spawn.go
+++ b/actor/spawn.go
@@ -126,26 +126,26 @@ func (x *actorSystem) Spawn(ctx context.Context, name string, actor Actor, opts 
 		return newRemotePID(address, x.remoting), nil
 	}
 
-	// check some preconditions
-	if err := x.checkSpawnPreconditions(ctx, name); err != nil {
-		return nil, err
-	}
-
-	pidNode, exist := x.actors.nodeByName(name)
-	if exist {
-		pid := pidNode.value()
-		if pid.IsRunning() {
-			return pid, nil
+	return x.runSpawnActivation(ctx, x.actorAddress(name).String(), func() (*PID, error) {
+		// check some preconditions
+		if err := x.checkSpawnPreconditions(ctx, name); err != nil {
+			return nil, err
 		}
-	}
 
-	pid, err := x.configPID(ctx, name, actor, opts...)
-	if err != nil {
-		return nil, err
-	}
+		if pidNode, exist := x.actors.nodeByName(name); exist {
+			if pid := pidNode.value(); pid != nil && pid.IsRunning() {
+				return pid, nil
+			}
+		}
 
-	// add the given actor to the tree, supervise it and publish it to the cluster
-	return x.completeSpawn(ctx, x.getUserGuardian(), pid)
+		pid, err := x.configPID(ctx, name, actor, opts...)
+		if err != nil {
+			return nil, err
+		}
+
+		// add the given actor to the tree, supervise it and publish it to the cluster
+		return x.completeSpawn(ctx, x.getUserGuardian(), pid)
+	})
 }
 
 // SpawnNamedFromFunc creates and starts an actor whose behavior is defined by the given receive function,
@@ -174,25 +174,25 @@ func (x *actorSystem) SpawnNamedFromFunc(ctx context.Context, name string, recei
 	config := newFuncConfig(opts...)
 	actor := newFuncActor(name, receiveFunc, config)
 
-	// check some preconditions
-	if err := x.checkSpawnPreconditions(ctx, name); err != nil {
-		return nil, err
-	}
-
-	pidNode, exist := x.actors.nodeByName(name)
-	if exist {
-		pid := pidNode.value()
-		if pid.IsRunning() {
-			return pid, nil
+	return x.runSpawnActivation(ctx, x.actorAddress(name).String(), func() (*PID, error) {
+		// check some preconditions
+		if err := x.checkSpawnPreconditions(ctx, name); err != nil {
+			return nil, err
 		}
-	}
 
-	pid, err := x.configPID(ctx, name, actor, WithMailbox(config.mailbox), WithRelocationDisabled())
-	if err != nil {
-		return nil, err
-	}
+		if pidNode, exist := x.actors.nodeByName(name); exist {
+			if pid := pidNode.value(); pid != nil && pid.IsRunning() {
+				return pid, nil
+			}
+		}
 
-	return x.completeSpawn(ctx, x.userGuardian, pid)
+		pid, err := x.configPID(ctx, name, actor, WithMailbox(config.mailbox), WithRelocationDisabled())
+		if err != nil {
+			return nil, err
+		}
+
+		return x.completeSpawn(ctx, x.userGuardian, pid)
+	})
 }
 
 // SpawnOn creates and starts an actor locally, on another node in the current cluster,
@@ -455,25 +455,74 @@ func (x *actorSystem) retrySpawnSingleton(ctx context.Context, cfg *clusterSingl
 	}
 
 	var pid *PID
+	// confirmedAddr is populated by the conflict handler when it verifies (via the
+	// cluster registry) that the name is already bound to the singleton we intended.
+	// It lets us resolve the idempotent-success PID from the address we already read,
+	// instead of issuing a second lookup that could momentarily observe the record as
+	// missing and surface a misleading ErrActorNotFound from this creation call.
+	var confirmedAddr string
 	retrier := retry.NewRetrier(cfg.numberOfRetries, cfg.waitInterval, cfg.spawnTimeout)
 	if err := retrier.RunContext(retryCtx, func(ctx context.Context) error {
 		var err error
 		pid, err = spawnFn(ctx)
 		if err != nil {
-			return x.spawnSingletonRetryError(ctx, err, kind, role, actorName)
+			return x.spawnSingletonRetryError(ctx, err, kind, role, actorName, &confirmedAddr)
 		}
 		return nil
 	}); err != nil {
 		return nil, cluster.NormalizeQuorumError(err)
 	}
 
+	// A successful retrier run can still leave pid == nil: when a spawn attempt returns
+	// ErrActorAlreadyExists and spawnSingletonRetryError downgrades it to success (the name
+	// is already bound to the singleton we intended), the attempt produced no PID. This is
+	// the idempotent-success path — the singleton exists (created concurrently, by a prior
+	// call, or on the leader), so resolve a usable reference to it rather than returning nil.
 	if pid == nil {
-		// Idempotent success: the name is already bound to the singleton we wanted
-		// (created concurrently or by a previous call). Resolve and return its PID
-		// so callers and the RemoteSpawn handler always get a usable reference.
-		return x.ActorOf(ctx, actorName)
+		return x.resolveExistingSingleton(ctx, actorName, confirmedAddr)
 	}
 
+	return pid, nil
+}
+
+// resolveExistingSingleton returns a usable PID for a singleton that already exists,
+// as confirmed on the idempotent-success path of retrySpawnSingleton.
+//
+// It prefers a live local PID when the singleton is hosted on this node. Otherwise it
+// builds a remote reference from confirmedAddr, the address captured while confirming
+// the name conflict, avoiding a redundant cluster read and the propagation race it can
+// lose. Only when no address was captured (e.g. the record became visible after an
+// ambiguous, retryable state) does it fall back to resolving by name via ActorOf.
+//
+// The singleton has already been confirmed to exist on this path, so a not-found result
+// from the fallback lookup is a transient resolution failure, not a genuine absence. It
+// is therefore never surfaced as ErrActorNotFound: a creation call must not tell the
+// caller the actor it just created does not exist.
+func (x *actorSystem) resolveExistingSingleton(ctx context.Context, actorName, confirmedAddr string) (*PID, error) {
+	if pidnode, ok := x.actors.nodeByName(actorName); ok {
+		if pid := pidnode.value(); pid != nil && !pid.IsStopping() {
+			return pid, nil
+		}
+	}
+
+	if strings.TrimSpace(confirmedAddr) != "" {
+		addr, err := address.Parse(confirmedAddr)
+		if err != nil {
+			return nil, err
+		}
+		return newRemotePID(addr, x.remoting), nil
+	}
+
+	pid, err := x.ActorOf(ctx, actorName)
+	if err != nil {
+		if errors.Is(err, gerrors.ErrActorNotFound) {
+			// Deliberately break the ErrActorNotFound chain (no %w): the singleton was
+			// confirmed to exist, so callers creating a singleton must never receive a
+			// not-found error describing the actor they just created.
+			return nil, fmt.Errorf("singleton %q is registered but its address could not be resolved", actorName)
+		}
+		return nil, err
+	}
 	return pid, nil
 }
 
@@ -494,14 +543,18 @@ func (x *actorSystem) retrySpawnSingleton(ctx context.Context, cfg *clusterSingl
 //
 // `kind` and `role` identify the singleton we attempted to spawn. They are used to disambiguate
 // name collisions (ErrActorAlreadyExists) by comparing against the registry record bound to the name.
-func (x *actorSystem) spawnSingletonRetryError(ctx context.Context, err error, kind, role, actorName string) error {
+//
+// confirmedAddr is an out-parameter: when the error is downgraded to idempotent success because
+// the name is already bound to the singleton we intended, it is set to that singleton's address so
+// the caller can resolve its PID without a second cluster lookup.
+func (x *actorSystem) spawnSingletonRetryError(ctx context.Context, err error, kind, role, actorName string, confirmedAddr *string) error {
 	if errors.Is(err, gerrors.ErrSingletonAlreadyExists) { //nolint:staticcheck // old-version hosts still emit it during a rolling upgrade
 		// Terminal: emitted by an old-version host during a mixed-version rolling upgrade; don't retry.
 		return retry.Stop(err)
 	}
 
 	if errors.Is(err, gerrors.ErrActorAlreadyExists) {
-		return x.handleSingletonNameConflict(ctx, err, kind, role, actorName)
+		return x.handleSingletonNameConflict(ctx, err, kind, role, actorName, confirmedAddr)
 	}
 
 	if isContextDone(ctx) {
@@ -526,10 +579,10 @@ func (x *actorSystem) spawnSingletonRetryError(ctx context.Context, err error, k
 // effectively done.
 //
 // It returns:
-//   - nil: treat as success (idempotent)
+//   - nil: treat as success (idempotent); confirmedAddr is set to the singleton's address
 //   - retry.Stop(err): terminal failure
 //   - err: retryable (within the configured retry budget)
-func (x *actorSystem) handleSingletonNameConflict(ctx context.Context, err error, kind, role, actorName string) error {
+func (x *actorSystem) handleSingletonNameConflict(ctx context.Context, err error, kind, role, actorName string, confirmedAddr *string) error {
 	if strings.TrimSpace(actorName) == "" {
 		return retry.Stop(err)
 	}
@@ -544,6 +597,10 @@ func (x *actorSystem) handleSingletonNameConflict(ctx context.Context, err error
 		actualRole := strings.TrimSpace(pointer.Deref(existing.Role, ""))
 		if existing.GetSingleton() != nil && existing.GetType() == kind && actualRole == role {
 			// The name is already bound to the singleton we wanted: treat as success/idempotent.
+			// Hand back the address we just read so the caller can resolve the PID directly.
+			if confirmedAddr != nil {
+				*confirmedAddr = existing.GetAddress()
+			}
 			return nil
 		}
 		// Name is taken by another actor (or a different singleton): stop.
@@ -586,7 +643,8 @@ func shouldRetrySpawnSingleton(err error) bool {
 	// equivalents. Without recognizing them here, a node calling SpawnSingleton during
 	// membership churn (e.g. a rolling restart) would fail terminally instead of retrying
 	// within its budget until the cluster settles:
-	//   - ErrRemoteSendFailure: CODE_UNAVAILABLE, mapped from leader quorum errors.
+	//   - ErrRemoteSendFailure: CODE_UNAVAILABLE, mapped (spawnErrorToProto) from leader
+	//     quorum errors, ErrLeaderNotFound, ErrEngineNotRunning, and no-role-members.
 	//   - ErrRequestTimeout:     CODE_DEADLINE_EXCEEDED on the leader.
 	//   - ErrAddressNotFound:    CODE_NOT_FOUND from a stale coordinator view or a singleton
 	//     not yet placed while membership is reconciling.
@@ -694,42 +752,99 @@ func (x *actorSystem) spawnSingletonWithRole(ctx context.Context, cl cluster.Clu
 	return pid, nil
 }
 
+// runSpawnActivation serializes concurrent local spawns that share the same actor
+// identity (key). Concurrent callers coalesce onto a single execution and share its
+// result, so a given name yields exactly one PID even under heavy concurrency,
+// keeping name-based spawns (regular, function-based, singleton, and children)
+// idempotent. When key is empty the function runs without coordination.
+//
+// The wait is context-aware: a caller whose ctx expires stops waiting and returns
+// ctx.Err() while the in-flight spawn completes undisturbed for the remaining
+// callers. Because fn runs under the winning caller's context, a waiter can
+// inherit a failure caused by the winner's context rather than its own; when that
+// happens (shared context error, own context still live) the waiter retries once
+// instead of failing with a cancellation that was never its own.
+//
+// fn must not spawn an actor with the same identity from within (e.g. from the
+// actor's PreStart): such a re-entrant call coalesces onto its own in-flight
+// execution and only unblocks with an error once the caller's context expires.
+func (x *actorSystem) runSpawnActivation(ctx context.Context, key string, fn func() (*PID, error)) (*PID, error) {
+	if key == "" {
+		return fn()
+	}
+
+	// A context that is already done must not start (or join) a spawn nobody
+	// will wait for.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	retried := false
+	for {
+		ch := x.spawnActivation.DoChan(key, func() (any, error) {
+			return fn()
+		})
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case res := <-ch:
+			if res.Err != nil {
+				if !retried && res.Shared && ctx.Err() == nil &&
+					(errors.Is(res.Err, context.Canceled) || errors.Is(res.Err, context.DeadlineExceeded)) {
+					retried = true
+					continue
+				}
+				return nil, res.Err
+			}
+			pid, _ := res.Val.(*PID)
+			return pid, nil
+		}
+	}
+}
+
 func (x *actorSystem) spawnSingletonOnLocal(ctx context.Context, name string, actor Actor, role *string, spawnTimeout, waitInterval time.Duration, retries int32) (*PID, error) {
 	// Normalize role once
 	singletonRole := strings.TrimSpace(pointer.Deref(role, ""))
 
-	// check some preconditions
-	if err := x.checkSpawnPreconditions(ctx, name); err != nil {
-		return nil, err
-	}
+	return x.runSpawnActivation(ctx, x.actorAddress(name).String(), func() (*PID, error) {
+		// check some preconditions
+		if err := x.checkSpawnPreconditions(ctx, name); err != nil {
+			return nil, err
+		}
 
-	pid, err := x.configPID(ctx, name, actor,
-		WithLongLived(),
-		withSingleton(&singletonSpec{
-			SpawnTimeout: spawnTimeout,
-			WaitInterval: waitInterval,
-			MaxRetries:   retries,
-		}),
-		WithRole(singletonRole),
-		WithSupervisor(
-			supervisor.NewSupervisor(
-				supervisor.WithStrategy(supervisor.OneForOneStrategy),
-				supervisor.WithDirective(&gerrors.PanicError{}, supervisor.StopDirective),
-				supervisor.WithDirective(&gerrors.InternalError{}, supervisor.StopDirective),
-				supervisor.WithDirective(&runtime.PanicNilError{}, supervisor.StopDirective),
+		// A running local instance already satisfies the singleton contract; return
+		// it instead of creating (and immediately discarding) a duplicate.
+		if node, exist := x.actors.nodeByName(name); exist {
+			if pid := node.value(); pid != nil && pid.IsRunning() {
+				return pid, nil
+			}
+		}
+
+		pid, err := x.configPID(ctx, name, actor,
+			WithLongLived(),
+			withSingleton(&singletonSpec{
+				SpawnTimeout: spawnTimeout,
+				WaitInterval: waitInterval,
+				MaxRetries:   retries,
+			}),
+			WithRole(singletonRole),
+			WithSupervisor(
+				supervisor.NewSupervisor(
+					supervisor.WithStrategy(supervisor.OneForOneStrategy),
+					supervisor.WithDirective(&gerrors.PanicError{}, supervisor.StopDirective),
+					supervisor.WithDirective(&gerrors.InternalError{}, supervisor.StopDirective),
+					supervisor.WithDirective(&runtime.PanicNilError{}, supervisor.StopDirective),
+				),
 			),
-		),
-	)
-	if err != nil {
-		return nil, err
-	}
+		)
+		if err != nil {
+			return nil, err
+		}
 
-	// add the given actor to the tree, supervise it and publish it to the cluster
-	if _, err = x.completeSpawn(ctx, x.singletonManager, pid); err != nil {
-		return nil, err
-	}
-
-	return pid, nil
+		// add the given actor to the tree, supervise it and publish it to the cluster
+		return x.completeSpawn(ctx, x.singletonManager, pid)
+	})
 }
 
 // spawnOnDatacenter spawns an actor on a remote data center by sending a RemoteSpawn

--- a/actor/spawn_test.go
+++ b/actor/spawn_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/tochemey/goakt/v4/datacenter"
@@ -2199,5 +2200,256 @@ func TestSpawnOnImmediateCrossNodeVisibility(t *testing.T) {
 		reply, err := Ask(ctx, remotePID, new(testpb.TestReply), time.Second)
 		require.NoError(t, err, "actor=%s must be reachable from another node as soon as SpawnOn returns", name)
 		require.NotNil(t, reply)
+	}
+}
+
+// TestConcurrentSpawnSameNameCreatesSingleActor verifies that many goroutines
+// racing to Spawn the same name converge on a single live actor: only one
+// instance starts, every caller gets the same PID, and the tree holds exactly
+// one node for that name.
+func TestConcurrentSpawnSameNameCreatesSingleActor(t *testing.T) {
+	ctx := context.Background()
+	sys, err := NewActorSystem("testSys", WithLogger(log.DiscardLogger))
+	require.NoError(t, err)
+	require.NoError(t, sys.Start(ctx))
+	t.Cleanup(func() { _ = sys.Stop(ctx) })
+
+	starts := &atomic.Int64{}
+	pids, errs := spawnConcurrently(t, 64, func() (*PID, error) {
+		return sys.Spawn(ctx, "concurrent", &countingActor{starts: starts})
+	})
+
+	requireSamePID(t, pids, errs)
+	require.EqualValues(t, 1, starts.Load(), "more than one actor instance was created")
+
+	node, ok := sys.tree().nodeByName("concurrent")
+	require.True(t, ok)
+	require.Equal(t, pids[0], node.value())
+	require.EqualValues(t, 1, sys.NumActors())
+}
+
+// TestConcurrentSpawnNamedFromFuncSingleActor exercises the same race on the
+// function-based spawn path.
+func TestConcurrentSpawnNamedFromFuncSingleActor(t *testing.T) {
+	ctx := context.Background()
+	sys, err := NewActorSystem("testSys", WithLogger(log.DiscardLogger))
+	require.NoError(t, err)
+	require.NoError(t, sys.Start(ctx))
+	t.Cleanup(func() { _ = sys.Stop(ctx) })
+
+	receiveFn := func(context.Context, any) error { return nil }
+	pids, errs := spawnConcurrently(t, 64, func() (*PID, error) {
+		return sys.SpawnNamedFromFunc(ctx, "func-actor", receiveFn)
+	})
+
+	requireSamePID(t, pids, errs)
+	node, ok := sys.tree().nodeByName("func-actor")
+	require.True(t, ok)
+	require.Equal(t, pids[0], node.value())
+	require.EqualValues(t, 1, sys.NumActors())
+}
+
+// TestConcurrentSpawnChildCreatesSingleChild exercises the race on the child
+// spawn path (PID.SpawnChild).
+func TestConcurrentSpawnChildCreatesSingleChild(t *testing.T) {
+	ctx := context.Background()
+	sys, err := NewActorSystem("testSys", WithLogger(log.DiscardLogger))
+	require.NoError(t, err)
+	require.NoError(t, sys.Start(ctx))
+	t.Cleanup(func() { _ = sys.Stop(ctx) })
+
+	parent, err := sys.Spawn(ctx, "parent", NewMockActor())
+	require.NoError(t, err)
+
+	starts := &atomic.Int64{}
+	pids, errs := spawnConcurrently(t, 64, func() (*PID, error) {
+		return parent.SpawnChild(ctx, "child", &countingActor{starts: starts})
+	})
+
+	requireSamePID(t, pids, errs)
+	require.EqualValues(t, 1, starts.Load(), "more than one child instance was created")
+
+	children := parent.Children()
+	require.Len(t, children, 1)
+	require.Equal(t, pids[0], children[0])
+}
+
+// TestCompleteSpawnDuplicateReturnsCanonical exercises the completeSpawn safety
+// net directly (bypassing the singleflight serialization): completing the spawn
+// of a second, distinct PID instance for an already-registered identity must
+// return the canonical instance, leave the canonical tree node intact and
+// running, and must not inflate the actors counter.
+func TestCompleteSpawnDuplicateReturnsCanonical(t *testing.T) {
+	ctx := context.Background()
+	sys, err := NewActorSystem("testSys", WithLogger(log.DiscardLogger))
+	require.NoError(t, err)
+	require.NoError(t, sys.Start(ctx))
+	t.Cleanup(func() { _ = sys.Stop(ctx) })
+
+	actorSys := sys.(*actorSystem)
+	canonical, err := sys.Spawn(ctx, "dup", NewMockActor())
+	require.NoError(t, err)
+	before := sys.NumActors()
+
+	// A distinct instance sharing the same identity (name/address).
+	duplicate, err := actorSys.configPID(ctx, "dup", NewMockActor())
+	require.NoError(t, err)
+	require.NotSame(t, canonical, duplicate)
+
+	got, err := actorSys.completeSpawn(ctx, actorSys.getUserGuardian(), duplicate)
+	require.NoError(t, err)
+	require.Same(t, canonical, got, "completeSpawn must return the canonical instance")
+	require.Equal(t, before, sys.NumActors(), "duplicate handling must undo the counter bump")
+
+	// The canonical node survives duplicate handling: still in the tree, still
+	// the same instance, still running.
+	node, ok := actorSys.tree().nodeByName("dup")
+	require.True(t, ok)
+	require.Same(t, canonical, node.value())
+	require.True(t, canonical.IsRunning())
+
+	// NOTE: the duplicate is intentionally not shut down here (and completeSpawn
+	// intentionally does not stop it): its shutdown would resolve tree state by
+	// the shared pid.ID() and detach the canonical node.
+}
+
+// TestTreeAddNodeDuplicateReturnsSentinel asserts the tree reports a duplicate
+// insertion with the typed sentinel completeSpawn relies on.
+func TestTreeAddNodeDuplicateReturnsSentinel(t *testing.T) {
+	ctx := context.Background()
+	sys, err := NewActorSystem("testSys", WithLogger(log.DiscardLogger))
+	require.NoError(t, err)
+	require.NoError(t, sys.Start(ctx))
+	t.Cleanup(func() { _ = sys.Stop(ctx) })
+
+	actorSys := sys.(*actorSystem)
+	pid, err := sys.Spawn(ctx, "sentinel", NewMockActor())
+	require.NoError(t, err)
+
+	err = actorSys.tree().addNode(actorSys.getUserGuardian(), pid)
+	require.ErrorIs(t, err, errNodeAlreadyExists)
+}
+
+// TestRunSpawnActivationHonorsCallerContext verifies the wait on an in-flight
+// spawn is context-aware: a waiter whose context is canceled stops waiting with
+// ctx.Err() instead of blocking until the winner finishes, an already-done
+// context is rejected without starting or joining a flight, and in both cases
+// the caller's own spawn function never runs.
+func TestRunSpawnActivationHonorsCallerContext(t *testing.T) {
+	x := new(actorSystem)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	winnerDone := make(chan struct{})
+	go func() {
+		defer close(winnerDone)
+		_, _ = x.runSpawnActivation(context.Background(), "key", func() (*PID, error) {
+			close(started)
+			<-release
+			return nil, nil
+		})
+	}()
+	<-started
+
+	// a waiter abandons the in-flight spawn when its own context is canceled
+	ctx, cancel := context.WithCancel(context.Background())
+	ran := atomic.NewBool(false)
+	waiterErr := make(chan error, 1)
+	go func() {
+		_, err := x.runSpawnActivation(ctx, "key", func() (*PID, error) {
+			ran.Store(true)
+			return nil, nil
+		})
+		waiterErr <- err
+	}()
+	pause.For(50 * time.Millisecond) // let the waiter join the flight
+	cancel()
+	require.ErrorIs(t, <-waiterErr, context.Canceled)
+	require.False(t, ran.Load(), "the abandoned caller's spawn function must not run")
+
+	// an already-done context is rejected upfront, while the flight is still in progress
+	_, err := x.runSpawnActivation(ctx, "key", func() (*PID, error) {
+		ran.Store(true)
+		return nil, nil
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, ran.Load(), "the rejected caller's spawn function must not run")
+
+	close(release)
+	<-winnerDone
+}
+
+// TestRunSpawnActivationRetriesInheritedCancellation verifies a waiter does not
+// fail with a cancellation that was never its own: when the winning caller's
+// context aborts the shared spawn, a waiter whose context is still live re-runs
+// the spawn once instead of surfacing the winner's context error.
+func TestRunSpawnActivationRetriesInheritedCancellation(t *testing.T) {
+	x := new(actorSystem)
+
+	winnerCtx, winnerCancel := context.WithCancel(context.Background())
+	entered := make(chan struct{})
+	winnerDone := make(chan error, 1)
+	go func() {
+		_, err := x.runSpawnActivation(winnerCtx, "key", func() (*PID, error) {
+			close(entered)
+			// the winner's spawn is aborted by its own context
+			<-winnerCtx.Done()
+			return nil, winnerCtx.Err()
+		})
+		winnerDone <- err
+	}()
+	<-entered
+
+	// join the in-flight spawn as a waiter with a healthy context
+	reran := atomic.NewBool(false)
+	waiterDone := make(chan error, 1)
+	go func() {
+		_, err := x.runSpawnActivation(context.Background(), "key", func() (*PID, error) {
+			reran.Store(true)
+			return nil, nil
+		})
+		waiterDone <- err
+	}()
+
+	// let the waiter coalesce onto the winner's flight, then abort the winner.
+	// If the waiter joins late it simply starts its own flight, which passes too.
+	pause.For(50 * time.Millisecond)
+	winnerCancel()
+
+	require.ErrorIs(t, <-winnerDone, context.Canceled)
+	require.NoError(t, <-waiterDone)
+	require.True(t, reran.Load(), "the waiter must re-run the spawn after inheriting the winner's cancellation")
+}
+
+// spawnConcurrently runs spawn from n goroutines released simultaneously and
+// returns their results.
+func spawnConcurrently(t *testing.T, n int, spawn func() (*PID, error)) ([]*PID, []error) {
+	t.Helper()
+	var wg sync.WaitGroup
+	gate := make(chan struct{})
+	pids := make([]*PID, n)
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-gate
+			pids[i], errs[i] = spawn()
+		}(i)
+	}
+	close(gate)
+	wg.Wait()
+	return pids, errs
+}
+
+// requireSamePID asserts every spawn succeeded, is running, and returned the
+// same PID.
+func requireSamePID(t *testing.T, pids []*PID, errs []error) {
+	t.Helper()
+	for i, pid := range pids {
+		require.NoErrorf(t, errs[i], "call %d failed", i)
+		require.NotNilf(t, pid, "call %d returned a nil pid", i)
+		require.Truef(t, pid.IsRunning(), "call %d returned a non-running pid", i)
+		require.Truef(t, pids[0].Equals(pid), "call %d returned a different pid", i)
 	}
 }


### PR DESCRIPTION
Concurrent local spawns of the same name could each create a live PID.  
`completeSpawn` swallowed the tree-insertion conflict and returned an unsupervised orphan whose later shutdown detached the canonical actor from the tree (both PIDs share `pid.ID()`).

### Fixes & Improvements

- **Serialize spawns** Serialize `Spawn`, `SpawnNamedFromFunc`, `SpawnChild`, and the singleton local path through a singleflight group keyed by actor address.This ensures a name yields exactly one PID under concurrency. The wait is context-aware, and a waiter that inherits the winner's context cancellation while its own context is still live retries once.

- **Safety net in `completeSpawn`** On a duplicate insertion (typed `errNodeAlreadyExists`):
  - Return the canonical instance  
  - Undo the actor counter bump  
  - Emit a warning  

  **Important:** Never stop the duplicate, since shutdown resolves tree state by the shared ID and would detach the canonical actor.

- **Idempotent singleton resolution** Resolve the singleton *idempotent-success* path from the address confirmed during conflict handling instead of performing a second lookup. Never surface `ErrActorNotFound` from a creation call.

- **Retryable leader-delegated errors** Serialize transient leader-delegated conditions:
  - `ErrLeaderNotFound`  
  - `ErrEngineNotRunning`  
  - No role members  

Return `CODE_UNAVAILABLE` instead of `CODE_INTERNAL_ERROR`, ensuring a delegated `SpawnSingleton` remains retryable during membership churn.