### PR TITLE
perf: skip cluster registry reads/writes when resolving an already active grain

### DIFF
--- a/actor/grain_engine.go
+++ b/actor/grain_engine.go
@@ -202,6 +202,13 @@ func staticGrainProvider(grain Grain) grainProvider {
 // activateGrain resolves the grain owner and activates the grain remotely or
 // locally. It is the shared orchestration behind GrainIdentity and GrainOf.
 func (x *actorSystem) activateGrain(ctx context.Context, identity *GrainIdentity, provider grainProvider, config *grainConfig) (*GrainIdentity, error) {
+	// Fast path: see remoteTellGrain. A locally active grain is owned here,
+	// so skip the per-call registry reads and write.
+	if process, ok := x.grains.Get(identity.String()); ok &&
+		process.isActive() && x.registry.Exists(process.getGrain()) {
+		return identity, nil
+	}
+
 	x.logger.Debugf("activating grain=%s", identity.String())
 	owner, err := x.resolveGrainOwner(ctx, identity)
 	if err != nil {

--- a/actor/grain_engine_test.go
+++ b/actor/grain_engine_test.go
@@ -655,6 +655,157 @@ func TestActivateGrainLocally(t *testing.T) {
 	})
 }
 
+func TestActivateGrainLocalActiveFastPath(t *testing.T) {
+	t.Run("locally active grain skips the cluster registry", func(t *testing.T) {
+		ctx := t.Context()
+		grain := NewMockGrain()
+		sys, _, _, identity := newActivationTestSystem(t, grain, "fast-path-active", true)
+		pid := newGrainPID(identity, grain, sys, newGrainConfig())
+		pid.activated.Store(true)
+		sys.grains.Set(identity.String(), pid)
+
+		// no cluster expectations: any registry call fails the test
+		got, err := sys.GrainIdentity(ctx, identity.Name(), func(context.Context) (Grain, error) {
+			return grain, nil
+		})
+		require.NoError(t, err)
+		require.True(t, identity.Equal(got))
+	})
+
+	t.Run("deregistered active grain is registered again", func(t *testing.T) {
+		ctx := t.Context()
+		grain := NewMockGrain()
+		sys, _, _, identity := newActivationTestSystem(t, grain, "fast-path-deregistered", true)
+		sys.clusterEnabled.Store(false)
+
+		pid := newGrainPID(identity, grain, sys, newGrainConfig())
+		pid.activated.Store(true)
+		sys.grains.Set(identity.String(), pid)
+		require.NoError(t, sys.DeregisterGrainKind(ctx, grain))
+		require.False(t, sys.registry.Exists(grain))
+
+		got, err := sys.GrainIdentity(ctx, identity.Name(), func(context.Context) (Grain, error) {
+			return grain, nil
+		})
+		require.NoError(t, err)
+		require.True(t, identity.Equal(got))
+		require.True(t, sys.registry.Exists(grain))
+	})
+
+	t.Run("repeat GrainOf resolves without registry traffic", func(t *testing.T) {
+		ctx := t.Context()
+		name := "fast-path-grainof"
+		identity := newGrainIdentity((*grainOfCounterGrain)(nil), name)
+		localPeer := &cluster.Peer{Host: "127.0.0.1", PeersPort: 14040, RemotingPort: 8100}
+
+		cl := mockcluster.NewCluster(t)
+		rem := mockremote.NewClient(t)
+		node := &discovery.Node{Host: localPeer.Host, PeersPort: localPeer.PeersPort, RemotingPort: localPeer.RemotingPort}
+		sys := MockSimpleClusterReadyActorSystem(rem, cl, node)
+
+		// the slow path runs exactly once; any repeat run would exceed these counts
+		cl.EXPECT().GrainExists(mock.Anything, identity.String()).Return(false, nil).Twice()
+		cl.EXPECT().Members(ctx).Return([]*cluster.Peer{localPeer}, nil).Once()
+		cl.EXPECT().PutGrain(mock.Anything, mock.MatchedBy(func(actual *internalpb.Grain) bool {
+			return actual != nil && actual.GetGrainId().GetValue() == identity.String()
+		})).Return(nil).Twice()
+
+		grainOfCounterActivations.Store(0)
+
+		first, err := GrainOf[*grainOfCounterGrain](ctx, sys, name)
+		require.NoError(t, err)
+		require.NotNil(t, first)
+
+		// the issue's repro: resolving the same identity in a loop from the
+		// same node must produce no further registry traffic
+		for range 10 {
+			got, err := GrainOf[*grainOfCounterGrain](ctx, sys, name)
+			require.NoError(t, err)
+			require.True(t, first.Equal(got))
+		}
+
+		require.EqualValues(t, 1, grainOfCounterActivations.Load())
+	})
+
+	t.Run("deactivated grain reactivates through the slow path", func(t *testing.T) {
+		ctx := t.Context()
+		grain := NewMockGrain()
+		sys, cl, _, identity := newActivationTestSystem(t, grain, "fast-path-reactivate", true)
+
+		// a deactivated local entry with no cluster record, as left behind by
+		// an idle deactivation
+		pid := newGrainPID(identity, grain, sys, newGrainConfig())
+		sys.grains.Set(identity.String(), pid)
+
+		cl.EXPECT().GrainExists(mock.Anything, identity.String()).Return(false, nil).Twice()
+		cl.EXPECT().Members(ctx).Return([]*cluster.Peer{{Host: sys.clusterNode.Host, PeersPort: sys.clusterNode.PeersPort, RemotingPort: sys.clusterNode.RemotingPort}}, nil).Once()
+		cl.EXPECT().PutGrain(mock.Anything, mock.MatchedBy(func(actual *internalpb.Grain) bool {
+			return actual != nil && actual.GetGrainId().GetValue() == identity.String()
+		})).Return(nil).Twice()
+
+		got, err := sys.activateGrain(ctx, identity, staticGrainProvider(grain), newGrainConfig())
+		require.NoError(t, err)
+		require.True(t, identity.Equal(got))
+		require.True(t, pid.isActive())
+	})
+
+	t.Run("inactive local grain falls through to ownership resolution", func(t *testing.T) {
+		ctx := t.Context()
+		grain := NewMockGrain()
+		sys, cl, rem, identity := newActivationTestSystem(t, grain, "fast-path-inactive", true)
+
+		// a deactivated local entry, as left behind by a relocation handoff
+		pid := newGrainPID(identity, grain, sys, newGrainConfig())
+		sys.grains.Set(identity.String(), pid)
+
+		owner := internalpb.Grain_builder{
+			GrainId: internalpb.GrainId_builder{Value: identity.String(), Kind: identity.Kind(), Name: identity.Name()}.Build(),
+			Host:    "192.0.2.80",
+			Port:    16080,
+		}.Build()
+
+		// the registry stays authoritative for a grain that is not live here
+		cl.EXPECT().GrainExists(mock.Anything, identity.String()).Return(true, nil).Once()
+		cl.EXPECT().GetGrain(mock.Anything, identity.String()).Return(owner, nil).Once()
+		rem.EXPECT().RemoteActivateGrain(ctx, owner.GetHost(), int(owner.GetPort()), mock.MatchedBy(func(req *remote.GrainRequest) bool {
+			return req != nil && req.Name == identity.Name() && req.Kind == identity.Kind()
+		})).Return(nil).Once()
+
+		got, err := sys.activateGrain(ctx, identity, staticGrainProvider(grain), newGrainConfig())
+		require.NoError(t, err)
+		require.True(t, identity.Equal(got))
+	})
+
+	t.Run("deregistered kind falls through and re-registers", func(t *testing.T) {
+		ctx := t.Context()
+		grain := NewMockGrain()
+		sys, cl, _, identity := newActivationTestSystem(t, grain, "fast-path-deregistered-cluster", true)
+
+		pid := newGrainPID(identity, grain, sys, newGrainConfig())
+		pid.activated.Store(true)
+		sys.grains.Set(identity.String(), pid)
+		sys.registry.Deregister(grain)
+
+		owner := internalpb.Grain_builder{
+			GrainId: internalpb.GrainId_builder{Value: identity.String(), Kind: identity.Kind(), Name: identity.Name()}.Build(),
+			Host:    sys.Host(),
+			Port:    int32(sys.Port()),
+		}.Build()
+
+		// the slow path runs: ownership is re-confirmed and the record republished
+		cl.EXPECT().GrainExists(mock.Anything, identity.String()).Return(true, nil).Once()
+		cl.EXPECT().GetGrain(mock.Anything, identity.String()).Return(owner, nil).Once()
+		cl.EXPECT().PutGrain(mock.Anything, mock.Anything).Return(nil).Once()
+
+		got, err := sys.GrainIdentity(ctx, identity.Name(), func(context.Context) (Grain, error) {
+			return grain, nil
+		})
+		require.NoError(t, err)
+		require.True(t, identity.Equal(got))
+		require.True(t, sys.registry.Exists(grain))
+	})
+}
+
 func TestFindActivationPeer_ErrorsWhenRoleMissingEverywhere(t *testing.T) {
 	ctx := t.Context()
 	cl := mockcluster.NewCluster(t)

--- a/actor/grain_test.go
+++ b/actor/grain_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/tochemey/goakt/v4/internal/internalpb"
 	"github.com/tochemey/goakt/v4/internal/pause"
 	"github.com/tochemey/goakt/v4/internal/types"
+	"github.com/tochemey/goakt/v4/internal/xsync"
 	"github.com/tochemey/goakt/v4/log"
 	mocks "github.com/tochemey/goakt/v4/mocks/cluster"
 	"github.com/tochemey/goakt/v4/test/data/testpb"
@@ -355,6 +356,7 @@ func TestGrain(t *testing.T) {
 			cluster:       clmock,
 			clusterConfig: NewClusterConfig(),
 			logger:        log.DiscardLogger,
+			grains:        xsync.NewMap[string, *grainPID](),
 		}
 		testSystem.started.Store(true)
 		testSystem.shuttingDown.Store(false)

--- a/changelogs/unreleased.md
+++ b/changelogs/unreleased.md
@@ -31,6 +31,7 @@
 - 🧵 Receive-context recycling now uses sharded pools, reducing contention and steady-state memory use.
 - ⚡ Dispatcher wake-ups now use direct worker handoff, removing a shared condition-variable bottleneck.
 - 💬 `Ask` uses per-request reply channels, removing global channel-pool contention and timeout reuse hazards.
+- ⚡ `GrainOf` and `GrainIdentity` now resolve an already active local grain without cluster registry reads or writes, matching the fast path `TellGrain` and `AskGrain` use ([#1307](https://github.com/Tochemey/goakt/issues/1307)).
 
 ## 🧪 Tests & Benchmarks
 


### PR DESCRIPTION
closes #1307 