### PR TITLE
fix: send the peer state snapshot over the pinned remoting protocol

### DIFF
--- a/actor/actor_system.go
+++ b/actor/actor_system.go
@@ -5372,19 +5372,6 @@ func (x *actorSystem) persistPeerStateToPeers(ctx context.Context, peerState *in
 	rpcCtx, cancelRPCs := context.WithCancel(ctx)
 	defer cancelRPCs()
 
-	// Create a custom remoting client for replication with compression enabled
-	remotingOpts := []remoteclient.ClientOption{
-		remoteclient.WithClientCompression(x.remoteConfig.Compression()),
-		remoteclient.WithClientContextPropagator(x.remoteConfig.ContextPropagator()),
-	}
-
-	if x.tlsInfo != nil {
-		remotingOpts = append(remotingOpts, remoteclient.WithClientTLS(x.tlsInfo.ClientConfig))
-	}
-
-	remoting := remoteclient.NewClient(remotingOpts...)
-	defer remoting.Close()
-
 	// Channel to collect results from all goroutines
 	// Each goroutine sends exactly one result (nil for success, error for failure)
 	results := make(chan error, totalPeers)
@@ -5392,31 +5379,14 @@ func (x *actorSystem) persistPeerStateToPeers(ctx context.Context, peerState *in
 	// Launch parallel RPCs to all selected peers
 	for _, peer := range peers {
 		go func() {
-			// Get pooled proto TCP client
-			client := remoting.NetClient(peer.Host, peer.RemotingPort)
-			request := &internalpb.PersistPeerStateRequest{}
-			request.SetPeerState(peerState)
-
-			// Send request using proto TCP
-			resp, err := client.SendProto(rpcCtx, request)
-			if err != nil {
-				x.logger.Errorf("node=%s failed to persist peer state to peer=%s:%d: %v (hint: check peer reachability)",
-					peerAddr, peer.Host, peer.RemotingPort, err)
-				results <- err
-				return
-			}
-
-			// Check for proto errors
-			if errResp, ok := resp.(*internalpb.Error); ok {
-				err := fmt.Errorf("proto error: code=%s, msg=%s", errResp.GetCode(), errResp.GetMessage())
-				x.logger.Errorf("node=%s failed to persist peer state to peer=%s:%d: %v (hint: check remote handler)",
-					peerAddr, peer.Host, peer.RemotingPort, err)
+			if err := x.remoting.PersistPeerState(rpcCtx, peer.Host, peer.RemotingPort, peerState); err != nil {
+				x.logger.Errorf("node=%s failed to persist peer state to peer=%s:%d: %v (hint: check peer reachability)", peerAddr, peer.Host, peer.RemotingPort, err)
 				results <- err
 				return
 			}
 
 			x.logger.Debugf("node=%s persisted peer state to peer=%s:%d", peerAddr, peer.Host, peer.RemotingPort)
-			results <- nil // Success
+			results <- nil
 		}()
 	}
 

--- a/actor/actor_system_test.go
+++ b/actor/actor_system_test.go
@@ -7366,6 +7366,24 @@ func TestPreShutdown(t *testing.T) {
 }
 
 func TestPersistPeerStateToPeers(t *testing.T) {
+	// replicationPeers returns the three peers selectOldestPeers keeps for a
+	// replication factor of three, oldest first.
+	replicationPeers := func() []*cluster.Peer {
+		return []*cluster.Peer{
+			{Host: "127.0.0.1", RemotingPort: 8081, PeersPort: 9001, CreatedAt: 1000},
+			{Host: "127.0.0.1", RemotingPort: 8082, PeersPort: 9002, CreatedAt: 2000},
+			{Host: "127.0.0.1", RemotingPort: 8083, PeersPort: 9003, CreatedAt: 3000},
+		}
+	}
+
+	// newPeerState returns the snapshot the departing node replicates.
+	newPeerState := func() *internalpb.PeerState {
+		return internalpb.PeerState_builder{
+			Host:      "127.0.0.1",
+			PeersPort: 9000,
+		}.Build()
+	}
+
 	t.Run("returns nil when peerState is nil", func(t *testing.T) {
 		ctx := context.TODO()
 		clusterMock := mockscluster.NewCluster(t)
@@ -7381,12 +7399,8 @@ func TestPersistPeerStateToPeers(t *testing.T) {
 		clusterMock.EXPECT().Peers(mock.Anything).Return([]*cluster.Peer{}, nil)
 
 		system := MockReplicationTestSystem(clusterMock)
-		peerState := internalpb.PeerState_builder{
-			Host:      "127.0.0.1",
-			PeersPort: 9000,
-		}.Build()
 
-		err := system.persistPeerStateToPeers(ctx, peerState)
+		err := system.persistPeerStateToPeers(ctx, newPeerState())
 		require.NoError(t, err)
 	})
 
@@ -7397,36 +7411,166 @@ func TestPersistPeerStateToPeers(t *testing.T) {
 		clusterMock.EXPECT().Peers(mock.Anything).Return(nil, expectedErr)
 
 		system := MockReplicationTestSystem(clusterMock)
-		peerState := internalpb.PeerState_builder{
-			Host:      "127.0.0.1",
-			PeersPort: 9000,
-		}.Build()
 
-		err := system.persistPeerStateToPeers(ctx, peerState)
+		err := system.persistPeerStateToPeers(ctx, newPeerState())
 		require.Error(t, err)
 		assert.Equal(t, expectedErr, err)
 	})
 
-	t.Run("handles context cancellation", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel() // Cancel immediately
-
+	t.Run("returns nil once the replication quorum acknowledges", func(t *testing.T) {
+		ctx := context.TODO()
 		clusterMock := mockscluster.NewCluster(t)
-		peers := []*cluster.Peer{
-			{Host: "127.0.0.1", RemotingPort: 8080, PeersPort: 9001, CreatedAt: 1000},
-		}
-		clusterMock.EXPECT().Peers(mock.Anything).Return(peers, nil)
+		clusterMock.EXPECT().Peers(mock.Anything).Return(replicationPeers(), nil)
+
+		// The third send is cancelled as soon as the quorum of two is reached,
+		// so no single peer is guaranteed to be reached.
+		remotingMock := mocksremote.NewClient(t)
+		remotingMock.EXPECT().PersistPeerState(mock.Anything, "127.0.0.1", 8081, mock.Anything).Return(nil).Maybe()
+		remotingMock.EXPECT().PersistPeerState(mock.Anything, "127.0.0.1", 8082, mock.Anything).Return(nil).Maybe()
+		remotingMock.EXPECT().PersistPeerState(mock.Anything, "127.0.0.1", 8083, mock.Anything).Return(nil).Maybe()
 
 		system := MockReplicationTestSystem(clusterMock)
-		peerState := internalpb.PeerState_builder{
-			Host:      "127.0.0.1",
-			PeersPort: 9000,
-		}.Build()
+		system.remoting = remotingMock
 
-		err := system.persistPeerStateToPeers(ctx, peerState)
-		// Should handle gracefully - either succeed with partial or return context error
-		// The exact behavior depends on timing
-		_ = err // Error is acceptable here due to context cancellation
+		err := system.persistPeerStateToPeers(ctx, newPeerState())
+		require.NoError(t, err)
+	})
+
+	t.Run("accepts a partial replication below the quorum", func(t *testing.T) {
+		ctx := context.TODO()
+		expectedErr := errors.New("peer unreachable")
+		clusterMock := mockscluster.NewCluster(t)
+		clusterMock.EXPECT().Peers(mock.Anything).Return(replicationPeers(), nil)
+
+		remotingMock := mocksremote.NewClient(t)
+		remotingMock.EXPECT().PersistPeerState(mock.Anything, "127.0.0.1", 8081, mock.Anything).Return(nil)
+		remotingMock.EXPECT().PersistPeerState(mock.Anything, "127.0.0.1", 8082, mock.Anything).Return(expectedErr)
+		remotingMock.EXPECT().PersistPeerState(mock.Anything, "127.0.0.1", 8083, mock.Anything).Return(expectedErr)
+
+		system := MockReplicationTestSystem(clusterMock)
+		system.remoting = remotingMock
+
+		err := system.persistPeerStateToPeers(ctx, newPeerState())
+		require.NoError(t, err)
+	})
+
+	t.Run("returns the last failure when no peer acknowledges", func(t *testing.T) {
+		ctx := context.TODO()
+		expectedErr := errors.New("peer unreachable")
+		clusterMock := mockscluster.NewCluster(t)
+		clusterMock.EXPECT().Peers(mock.Anything).Return(replicationPeers(), nil)
+
+		remotingMock := mocksremote.NewClient(t)
+		remotingMock.EXPECT().PersistPeerState(mock.Anything, "127.0.0.1", 8081, mock.Anything).Return(expectedErr)
+		remotingMock.EXPECT().PersistPeerState(mock.Anything, "127.0.0.1", 8082, mock.Anything).Return(expectedErr)
+		remotingMock.EXPECT().PersistPeerState(mock.Anything, "127.0.0.1", 8083, mock.Anything).Return(expectedErr)
+
+		system := MockReplicationTestSystem(clusterMock)
+		system.remoting = remotingMock
+
+		err := system.persistPeerStateToPeers(ctx, newPeerState())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, expectedErr)
+		assert.ErrorContains(t, err, "failed to replicate state to any peer")
+	})
+
+	t.Run("reports a bare failure when every send is cancelled", func(t *testing.T) {
+		ctx := context.TODO()
+		clusterMock := mockscluster.NewCluster(t)
+		clusterMock.EXPECT().Peers(mock.Anything).Return(replicationPeers(), nil)
+
+		// A cancelled send is not counted as a peer failure, so no error is
+		// carried over into the final message.
+		remotingMock := mocksremote.NewClient(t)
+		remotingMock.EXPECT().PersistPeerState(mock.Anything, "127.0.0.1", 8081, mock.Anything).Return(context.Canceled)
+		remotingMock.EXPECT().PersistPeerState(mock.Anything, "127.0.0.1", 8082, mock.Anything).Return(context.Canceled)
+		remotingMock.EXPECT().PersistPeerState(mock.Anything, "127.0.0.1", 8083, mock.Anything).Return(context.Canceled)
+
+		system := MockReplicationTestSystem(clusterMock)
+		system.remoting = remotingMock
+
+		err := system.persistPeerStateToPeers(ctx, newPeerState())
+		require.Error(t, err)
+		assert.EqualError(t, err, "failed to replicate state to any peer")
+		assert.NotErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("returns an error when the parent context is cancelled before any acknowledgement", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// release keeps every send in flight until the subtest is over, so the
+		// only way out of the collection loop is the parent cancellation.
+		release := make(chan struct{})
+		t.Cleanup(func() { close(release) })
+		started := make(chan struct{}, 3)
+
+		clusterMock := mockscluster.NewCluster(t)
+		clusterMock.EXPECT().Peers(mock.Anything).Return(replicationPeers(), nil)
+
+		block := func(context.Context, string, int, *internalpb.PeerState) error {
+			started <- struct{}{}
+			<-release
+			return nil
+		}
+
+		remotingMock := mocksremote.NewClient(t)
+
+		for _, port := range []int{8081, 8082, 8083} {
+			remotingMock.EXPECT().PersistPeerState(mock.Anything, "127.0.0.1", port, mock.Anything).RunAndReturn(block).Maybe()
+		}
+
+		system := MockReplicationTestSystem(clusterMock)
+		system.remoting = remotingMock
+
+		go func() {
+			<-started
+			cancel()
+		}()
+
+		err := system.persistPeerStateToPeers(ctx, newPeerState())
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "replication interrupted")
+	})
+
+	t.Run("returns nil when the parent context is cancelled after one acknowledgement", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		release := make(chan struct{})
+		t.Cleanup(func() { close(release) })
+		done := make(chan struct{})
+
+		clusterMock := mockscluster.NewCluster(t)
+		clusterMock.EXPECT().Peers(mock.Anything).Return(replicationPeers(), nil)
+
+		block := func(context.Context, string, int, *internalpb.PeerState) error {
+			<-release
+			return nil
+		}
+
+		remotingMock := mocksremote.NewClient(t)
+		remotingMock.EXPECT().PersistPeerState(mock.Anything, "127.0.0.1", 8081, mock.Anything).
+			RunAndReturn(func(context.Context, string, int, *internalpb.PeerState) error {
+				close(done)
+				return nil
+			})
+		remotingMock.EXPECT().PersistPeerState(mock.Anything, "127.0.0.1", 8082, mock.Anything).RunAndReturn(block).Maybe()
+		remotingMock.EXPECT().PersistPeerState(mock.Anything, "127.0.0.1", 8083, mock.Anything).RunAndReturn(block).Maybe()
+
+		system := MockReplicationTestSystem(clusterMock)
+		system.remoting = remotingMock
+
+		go func() {
+			<-done
+			// Let the collection loop count the acknowledgement before the
+			// parent cancellation makes both select cases ready.
+			pause.For(500 * time.Millisecond)
+			cancel()
+		}()
+
+		err := system.persistPeerStateToPeers(ctx, newPeerState())
+		require.NoError(t, err)
 	})
 }
 

--- a/actor/fixtures_test.go
+++ b/actor/fixtures_test.go
@@ -2085,6 +2085,7 @@ type testClusterConfig struct {
 	writeQuorum       uint32
 	readQuorum        uint32
 	bootstrapTimeout  time.Duration
+	protocolPin       remote.ProtocolPin
 }
 
 type testClusterOption func(*testClusterConfig)
@@ -2128,6 +2129,15 @@ func withTestReplication(replicaCount, writeQuorum, readQuorum uint32) testClust
 func withTestBootstrapTimeout(timeout time.Duration) testClusterOption {
 	return func(tc *testClusterConfig) {
 		tc.bootstrapTimeout = timeout
+	}
+}
+
+// withTestProtocolPin pins the remoting wire protocol of every node built by
+// the fixture, so a test can exercise a cluster that speaks only duplex or only
+// legacy remoting.
+func withTestProtocolPin(pin remote.ProtocolPin) testClusterOption {
+	return func(tc *testClusterConfig) {
+		tc.protocolPin = pin
 	}
 }
 
@@ -2318,7 +2328,7 @@ func buildTestSystem(t *testing.T, providerFactory providerFactory, opts ...test
 		options = append(options, WithExtensions(cfg.extension))
 	}
 
-	remoteOpts := []remote.Option{remote.WithCompression(cfg.compression)}
+	remoteOpts := []remote.Option{remote.WithCompression(cfg.compression), remote.WithProtocolPin(cfg.protocolPin)}
 	if cfg.contextPropagator != nil {
 		remoteOpts = append(remoteOpts, remote.WithContextPropagator(cfg.contextPropagator))
 	}

--- a/actor/relocator_test.go
+++ b/actor/relocator_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/tochemey/goakt/v4/internal/pause"
 	"github.com/tochemey/goakt/v4/log"
 	"github.com/tochemey/goakt/v4/reentrancy"
+	"github.com/tochemey/goakt/v4/remote"
 	"github.com/tochemey/goakt/v4/supervisor"
 	"github.com/tochemey/goakt/v4/test/data/testpb"
 )
@@ -524,6 +525,68 @@ func TestRelocation(t *testing.T) {
 	assert.NoError(t, node3.Stop(ctx))
 	assert.NoError(t, sd1.Close())
 	assert.NoError(t, sd3.Close())
+	srv.Shutdown()
+}
+
+// TestRelocationWithDuplexProtocolPin proves that a node leaving a cluster whose
+// remoting is pinned to the duplex protocol still hands its peer state snapshot
+// to the surviving peers, so the leader can relocate the departed node's actors.
+// The snapshot travels on the same protocol-pinned control path as every other
+// internal RPC; sending it over the legacy unary path leaves the leader without
+// a snapshot and the actors are never relocated.
+func TestRelocationWithDuplexProtocolPin(t *testing.T) {
+	ctx := context.TODO()
+	srv := startNatsServer(t)
+
+	node1, sd1 := testNATs(t, srv.Addr().String(), withTestProtocolPin(remote.ProtocolPinDuplex))
+	require.NotNil(t, node1)
+	require.NotNil(t, sd1)
+
+	node2, sd2 := testNATs(t, srv.Addr().String(), withTestProtocolPin(remote.ProtocolPinDuplex))
+	require.NotNil(t, node2)
+	require.NotNil(t, sd2)
+
+	senderName := "Sender-Actor"
+	senderPID, err := node1.Spawn(ctx, senderName, NewMockActor(), WithLongLived())
+	require.NoError(t, err)
+	require.NotNil(t, senderPID)
+
+	actorName := "Relocated-Actor"
+	pid, err := node2.Spawn(ctx, actorName, NewMockActor(), WithLongLived())
+	require.NoError(t, err)
+	require.NotNil(t, pid)
+
+	pause.For(time.Second)
+
+	node2Address := net.JoinHostPort(node2.Host(), strconv.Itoa(node2.Port()))
+	actorPID, err := node1.ActorOf(ctx, actorName)
+	require.NoError(t, err)
+	require.NotNil(t, actorPID)
+	require.Equal(t, node2Address, actorPID.Path().HostPort(), "Actor %s should be on node2 before shutdown", actorName)
+
+	require.NoError(t, node2.Stop(ctx))
+	require.NoError(t, sd2.Close())
+
+	require.Eventually(t, func() bool {
+		relocatedPID, err := node1.ActorOf(ctx, actorName)
+		if err != nil || relocatedPID == nil {
+			return false
+		}
+
+		return relocatedPID.Path().HostPort() != node2Address
+	}, 2*time.Minute, 500*time.Millisecond, "Actor %s should be relocated from node2 (was %s) to a live node", actorName, node2Address)
+
+	require.Eventually(t, func() bool {
+		sender, err := node1.ActorOf(ctx, senderName)
+		if err != nil || sender == nil {
+			return false
+		}
+
+		return sender.SendAsync(ctx, actorName, new(testpb.TestSend)) == nil
+	}, 30*time.Second, 500*time.Millisecond, "Should be able to send to relocated actor %s", actorName)
+
+	assert.NoError(t, node1.Stop(ctx))
+	assert.NoError(t, sd1.Close())
 	srv.Shutdown()
 }
 

--- a/changelogs/unreleased.md
+++ b/changelogs/unreleased.md
@@ -20,6 +20,8 @@
 
 - **Actors and grains carry their role constraint through relocation and remote activation** ([#1334](https://github.com/Tochemey/goakt/issues/1334)). Actors spawned with `WithRole` and grains activated with `WithActivationRole` lost their role when recreated on another node, because `SpawnOn`, the grain cluster record, and the remote activation request did not carry it. All three paths now transport the role, and eager grain relocation honors it: a role-constrained eager grain is reassigned to the least-loaded surviving node advertising its role, and reported in `RelocationFailed` when no surviving node qualifies. Lazy grains stay unconstrained during relocation; their role is re-applied at the next activation.
 
+- **Peer state replication honors the remoting protocol pin** ([#1343](https://github.com/Tochemey/goakt/issues/1343)). The peer state snapshot a node replicates to its peers during graceful shutdown was sent over the legacy unary remoting path regardless of the configured protocol pin. With `remote.WithProtocolPin(remote.ProtocolPinDuplex)` every peer refused the connection, the leader found no snapshot, and the departing node's actors and grains were never relocated. The snapshot now travels through the actor system's own remoting client, on the same protocol-pinned control path as every other internal RPC.
+
 ## 📦 Dependencies
 
 - Updated Go to v1.26.6 (`go.mod` and the build Dockerfile).

--- a/internal/remoteclient/client.go
+++ b/internal/remoteclient/client.go
@@ -344,6 +344,23 @@ type Client interface {
 	//     not as an error.
 	RelocateBatch(ctx context.Context, host string, port int, request *internalpb.RelocateBatchRequest) (*internalpb.RelocateBatchResponse, error)
 
+	// PersistPeerState hands a departing node's peer state snapshot to one peer
+	// before that node leaves the cluster, so the leader can relocate its actors
+	// and grains. It is an internal control RPC and follows the client's
+	// protocol pin like every other control RPC.
+	//
+	// Parameters:
+	//   - ctx: Governs cancellation and deadlines for the outbound RPC.
+	//   - host, port: Location of the peer that stores the snapshot.
+	//   - peerState: The departing node's actors and grains, with its own host and ports.
+	//
+	// Errors:
+	//   - Transport and context errors.
+	//   - Server-side failures surfaced as proto errors: FailedPrecondition when remoting
+	//     or clustering is disabled on the peer, Internal when its cluster store rejects
+	//     the snapshot.
+	PersistPeerState(ctx context.Context, host string, port int, peerState *internalpb.PeerState) error
+
 	// RemoteTellGrain sends a one-way (fire-and-forget) message to a grain.
 	//
 	// Parameters:
@@ -1668,6 +1685,46 @@ func (r *client) RelocateBatch(ctx context.Context, host string, port int, reque
 	}
 
 	return response, nil
+}
+
+// PersistPeerState hands a departing node's peer state snapshot to one peer
+// before that node leaves the cluster, so the leader can relocate its actors
+// and grains. It is an internal control RPC and follows the client's
+// protocol pin like every other control RPC.
+//
+// Parameters:
+//   - ctx: Governs cancellation and deadlines for the outbound RPC.
+//   - host, port: Location of the peer that stores the snapshot.
+//   - peerState: The departing node's actors and grains, with its own host and ports.
+//
+// Errors:
+//   - Transport and context errors.
+//   - Server-side failures surfaced as proto errors: FailedPrecondition when remoting
+//     or clustering is disabled on the peer, Internal when its cluster store rejects
+//     the snapshot.
+func (r *client) PersistPeerState(ctx context.Context, host string, port int, peerState *internalpb.PeerState) error {
+	ctx, err := r.enrichContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	request := &internalpb.PersistPeerStateRequest{}
+	request.SetPeerState(peerState)
+
+	resp, err := r.sendControl(ctx, host, port, request)
+	if err != nil {
+		return err
+	}
+
+	if err := checkProtoError(resp); err != nil {
+		return err
+	}
+
+	if _, ok := resp.(*internalpb.PersistPeerStateResponse); !ok {
+		return fmt.Errorf("unexpected response type %T", resp)
+	}
+
+	return nil
 }
 
 // RemoteAskGrain sends a request message to a grain and waits for a reply, subject to the provided timeout and context.

--- a/internal/remoteclient/client_test.go
+++ b/internal/remoteclient/client_test.go
@@ -2734,3 +2734,132 @@ func TestSerializePayload(t *testing.T) {
 		assert.False(t, pooled, "non-proto serializers must not hand out pooled frames")
 	})
 }
+
+// --- PersistPeerState tests ---
+
+// testPeerState builds the snapshot the PersistPeerState tests send, and whose
+// host and peers port the server-side handler asserts on.
+func testPeerState() *internalpb.PeerState {
+	return internalpb.PeerState_builder{
+		Host:         "127.0.0.1",
+		RemotingPort: 8080,
+		PeersPort:    9000,
+	}.Build()
+}
+
+// persistPeerStateHandler answers a PersistPeerStateRequest after checking that
+// the snapshot built by testPeerState survived the round trip intact.
+func persistPeerStateHandler(t *testing.T) inet.ProtoHandler {
+	t.Helper()
+	return func(_ context.Context, _ inet.Connection, msg proto.Message) (proto.Message, error) {
+		req := msg.(*internalpb.PersistPeerStateRequest)
+		assert.Equal(t, "127.0.0.1", req.GetPeerState().GetHost())
+		assert.EqualValues(t, 9000, req.GetPeerState().GetPeersPort())
+		return new(internalpb.PersistPeerStateResponse), nil
+	}
+}
+
+func TestPersistPeerState_Success(t *testing.T) {
+	ps := startRemotingServer(t,
+		inet.WithProtoHandler("internalpb.PersistPeerStateRequest", persistPeerStateHandler(t)),
+	)
+	host, port := serverHostPort(t, ps)
+
+	r := NewClient()
+	defer r.Close()
+
+	require.NoError(t, r.PersistPeerState(context.Background(), host, port, testPeerState()))
+}
+
+// TestPersistPeerState_DuplexPinnedPeer is the regression test for the snapshot
+// never reaching a duplex-pinned peer: the listener accepts only duplex, so a
+// client that sends the snapshot on the legacy unary path is refused.
+func TestPersistPeerState_DuplexPinnedPeer(t *testing.T) {
+	ps := startRemotingServer(t,
+		inet.WithRemotingServerAcceptProtocol(inet.AcceptProtocolDuplex),
+		inet.WithProtoHandler("internalpb.PersistPeerStateRequest", persistPeerStateHandler(t)),
+	)
+	host, port := serverHostPort(t, ps)
+
+	r := NewClient(
+		WithClientCompression(remote.NoCompression),
+		WithClientProtocolPin(remote.ProtocolPinDuplex),
+	)
+	defer r.Close()
+
+	c := r.(*client)
+	p := c.peerFor(host, port)
+
+	require.NoError(t, r.PersistPeerState(context.Background(), host, port, testPeerState()))
+	assert.Equal(t, peerProtocolDuplex, p.cachedProtocol())
+}
+
+func TestPersistPeerState_LegacyPinnedPeer(t *testing.T) {
+	ps := startRemotingServer(t,
+		inet.WithRemotingServerAcceptProtocol(inet.AcceptProtocolLegacy),
+		inet.WithProtoHandler("internalpb.PersistPeerStateRequest", persistPeerStateHandler(t)),
+	)
+	host, port := serverHostPort(t, ps)
+
+	r := NewClient(
+		WithClientCompression(remote.NoCompression),
+		WithClientProtocolPin(remote.ProtocolPinLegacy),
+	)
+	defer r.Close()
+
+	require.NoError(t, r.PersistPeerState(context.Background(), host, port, testPeerState()))
+}
+
+func TestPersistPeerState_ProtoError(t *testing.T) {
+	handler := func(_ context.Context, _ inet.Connection, _ proto.Message) (proto.Message, error) {
+		return internalpb.Error_builder{
+			Code:    internalpb.Code_CODE_FAILED_PRECONDITION,
+			Message: gerrors.ErrClusterDisabled.Error(),
+		}.Build(), nil
+	}
+
+	ps := startRemotingServer(t,
+		inet.WithProtoHandler("internalpb.PersistPeerStateRequest", handler),
+	)
+	host, port := serverHostPort(t, ps)
+
+	r := NewClient(WithClientCompression(remote.NoCompression))
+	defer r.Close()
+
+	err := r.PersistPeerState(context.Background(), host, port, testPeerState())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, gerrors.ErrClusterDisabled)
+}
+
+func TestPersistPeerState_InvalidResponseType(t *testing.T) {
+	handler := func(_ context.Context, _ inet.Connection, _ proto.Message) (proto.Message, error) {
+		return &internalpb.RemoteLookupResponse{}, nil
+	}
+
+	ps := startRemotingServer(t,
+		inet.WithProtoHandler("internalpb.PersistPeerStateRequest", handler),
+	)
+	host, port := serverHostPort(t, ps)
+
+	r := NewClient(WithClientCompression(remote.NoCompression))
+	defer r.Close()
+
+	err := r.PersistPeerState(context.Background(), host, port, testPeerState())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "unexpected response type")
+}
+
+func TestPersistPeerState_ConnectionRefused(t *testing.T) {
+	r := NewClient()
+	err := r.PersistPeerState(context.Background(), "host", 1000, testPeerState())
+	assert.Error(t, err)
+}
+
+func TestPersistPeerState_EnrichContextError(t *testing.T) {
+	r := NewClient(WithClientContextPropagator(errInjectPropagator{}))
+	defer r.Close()
+
+	err := r.PersistPeerState(context.Background(), "host", 1000, testPeerState())
+	require.Error(t, err)
+	assert.EqualError(t, err, "inject error")
+}

--- a/mocks/remoteclient/client.go
+++ b/mocks/remoteclient/client.go
@@ -78,7 +78,7 @@ func (_c *Client_Close_Call) RunAndReturn(run func()) *Client_Close_Call {
 	return _c
 }
 
-// ClosePeer provides a mock function for the type Client.
+// ClosePeer provides a mock function for the type Client
 func (_mock *Client) ClosePeer(host string, port int) {
 	_mock.Called(host, port)
 	return
@@ -92,7 +92,7 @@ type Client_ClosePeer_Call struct {
 // ClosePeer is a helper method to define mock.On call
 //   - host string
 //   - port int
-func (_e *Client_Expecter) ClosePeer(host interface{}, port interface{}) *Client_ClosePeer_Call {
+func (_e *Client_Expecter) ClosePeer(host any, port any) *Client_ClosePeer_Call {
 	return &Client_ClosePeer_Call{Call: _e.mock.On("ClosePeer", host, port)}
 }
 
@@ -309,6 +309,75 @@ func (_c *Client_NetClient_Call) Return(client *net.Client) *Client_NetClient_Ca
 }
 
 func (_c *Client_NetClient_Call) RunAndReturn(run func(host string, port int) *net.Client) *Client_NetClient_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// PersistPeerState provides a mock function for the type Client
+func (_mock *Client) PersistPeerState(ctx context.Context, host string, port int, peerState *internalpb.PeerState) error {
+	ret := _mock.Called(ctx, host, port, peerState)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PersistPeerState")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, *internalpb.PeerState) error); ok {
+		r0 = returnFunc(ctx, host, port, peerState)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// Client_PersistPeerState_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PersistPeerState'
+type Client_PersistPeerState_Call struct {
+	*mock.Call
+}
+
+// PersistPeerState is a helper method to define mock.On call
+//   - ctx context.Context
+//   - host string
+//   - port int
+//   - peerState *internalpb.PeerState
+func (_e *Client_Expecter) PersistPeerState(ctx any, host any, port any, peerState any) *Client_PersistPeerState_Call {
+	return &Client_PersistPeerState_Call{Call: _e.mock.On("PersistPeerState", ctx, host, port, peerState)}
+}
+
+func (_c *Client_PersistPeerState_Call) Run(run func(ctx context.Context, host string, port int, peerState *internalpb.PeerState)) *Client_PersistPeerState_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		var arg3 *internalpb.PeerState
+		if args[3] != nil {
+			arg3 = args[3].(*internalpb.PeerState)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *Client_PersistPeerState_Call) Return(err error) *Client_PersistPeerState_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *Client_PersistPeerState_Call) RunAndReturn(run func(ctx context.Context, host string, port int, peerState *internalpb.PeerState) error) *Client_PersistPeerState_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
closes #1343 