### PR TITLE
fix: preserve relocation state during shutdown and restart

### DIFF
--- a/actor/actor_system.go
+++ b/actor/actor_system.go
@@ -5313,6 +5313,16 @@ func (x *actorSystem) preShutdown() (*internalpb.PeerState, error) {
 			continue // actor is not relocatable, skip it
 		}
 
+		// localActors walks the actor tree, and a stopped actor stays in the
+		// tree until DeathWatch processes its Terminated message. That removal
+		// is asynchronous, so an actor the user shut down just before Stop, or
+		// one whose shutdown is still in progress, can still be listed here.
+		// Relocating it would resurrect an actor that was deliberately stopped
+		// on another node, so only actors that are still alive are snapshotted.
+		if !actor.isStateSet(runningState) || actor.isStateSet(stoppingState) {
+			continue
+		}
+
 		wireActor, err := actor.toSerialize()
 		if err != nil {
 			return nil, err

--- a/actor/actor_system_test.go
+++ b/actor/actor_system_test.go
@@ -7360,6 +7360,47 @@ func TestPreShutdown(t *testing.T) {
 		require.NoError(t, err)
 		assert.Nil(t, peerState)
 	})
+
+	t.Run("snapshots only live relocatable actors", func(t *testing.T) {
+		clusterMock := mockscluster.NewCluster(t)
+		system := newReplicationSystem(clusterMock)
+		system.relocationEnabled.Store(true)
+
+		newActor := func(name string) *PID {
+			pid := newPIDAt(system, name, 8080)
+			pid.actor = NewMockActor()
+			pid.setState(relocationState, true)
+			pid.setState(runningState, true)
+			return pid
+		}
+
+		running := newActor("running")
+
+		// a stopped actor stays in the tree until DeathWatch removes it
+		stopped := newActor("stopped")
+		stopped.setState(runningState, false)
+
+		// an actor whose shutdown is still in progress
+		stopping := newActor("stopping")
+		stopping.setState(stoppingState, true)
+
+		notRelocatable := newActor("notRelocatable")
+		notRelocatable.setState(relocationState, false)
+
+		tree := system.tree()
+		require.NoError(t, tree.addRootNode(running))
+		for _, pid := range []*PID{stopped, stopping, notRelocatable} {
+			require.NoError(t, tree.addNode(running, pid))
+		}
+
+		peerState, err := system.preShutdown()
+		require.NoError(t, err)
+		require.NotNil(t, peerState)
+
+		actors := peerState.GetActors()
+		require.Len(t, actors, 1)
+		require.Contains(t, actors, running.ID())
+	})
 }
 
 func TestPersistPeerStateToPeers(t *testing.T) {

--- a/actor/pid.go
+++ b/actor/pid.go
@@ -2645,11 +2645,20 @@ func (pid *PID) reset() {
 	}
 
 	pid.mailbox.Dispose()
-	pid.setState(singletonState, false)
-	pid.setState(relocationState, true)
+
+	// Note: singletonState and relocationState are deliberately left untouched as
+	// well: both are spawn-time configuration applied once by newPID through
+	// asSingleton and withRelocationDisabled. The restart path re-runs init()
+	// on the same PID without re-applying options, so flipping them back to
+	// their defaults here turned a WithRelocationDisabled actor into a
+	// relocatable one after Restart, and a stopped PID awaiting DeathWatch
+	// cleanup reported the wrong configuration to IsRelocatable, IsSingleton,
+	// toSerialize and the remote state endpoint (#1349).
+
 	if pid.dependencies != nil {
 		pid.dependencies.Reset()
 	}
+
 	pid.setState(passivationPausedState, false)
 	pid.setState(passivatingState, false)
 	pid.setState(passivationSkipNextState, false)
@@ -3746,6 +3755,7 @@ func buildRestartSubtree(root *PID, tree *tree) *restartNode {
 			nodes[descendant.ID()] = &restartNode{pid: descendant}
 		}
 	}
+
 	if len(nodes) == 0 {
 		return rootNode
 	}
@@ -3755,10 +3765,12 @@ func buildRestartSubtree(root *PID, tree *tree) *restartNode {
 		if !ok || parent == nil {
 			continue
 		}
+
 		if parent.Equals(root) {
 			rootNode.children = append(rootNode.children, node)
 			continue
 		}
+
 		if parentNode, ok := nodes[parent.ID()]; ok {
 			parentNode.children = append(parentNode.children, node)
 		}
@@ -3787,10 +3799,12 @@ func restartSubtree(ctx context.Context, node *restartNode, parent *PID, tree *t
 		if err := pid.Shutdown(ctx); err != nil {
 			return err
 		}
+
 		didShutdown = true
 		tk := ticker.New(10 * time.Millisecond)
 		tk.Start()
 		tickerStopSig := make(chan types.Unit, 1)
+
 		go func() {
 			for range tk.Ticks {
 				if !pid.IsRunning() {
@@ -3799,6 +3813,7 @@ func restartSubtree(ctx context.Context, node *restartNode, parent *PID, tree *t
 				}
 			}
 		}()
+
 		<-tickerStopSig
 		tk.Stop()
 	}

--- a/actor/pid_test.go
+++ b/actor/pid_test.go
@@ -8004,3 +8004,98 @@ func TestMailboxSize(t *testing.T) {
 		require.NoError(t, actorSystem.Stop(ctx))
 	})
 }
+
+func TestShutdownPreservesSpawnTimeConfiguration(t *testing.T) {
+	t.Run("relocation stays disabled after shutdown", func(t *testing.T) {
+		ctx := context.TODO()
+		actorSystem, err := NewActorSystem("testSys", WithLogger(log.DiscardLogger))
+		require.NoError(t, err)
+		require.NoError(t, actorSystem.Start(ctx))
+
+		parent, err := actorSystem.Spawn(ctx, "parent", NewMockActor(), WithLongLived(), WithRelocationDisabled())
+		require.NoError(t, err)
+		require.NotNil(t, parent)
+
+		child, err := parent.SpawnChild(ctx, "child", NewMockActor(), WithLongLived(), WithRelocationDisabled())
+		require.NoError(t, err)
+		require.NotNil(t, child)
+		require.False(t, child.IsRelocatable())
+
+		// the teardown must not flip a spawn-time option: a stopped PID that is
+		// still referenced (or still in the tree awaiting DeathWatch cleanup)
+		// keeps reporting the configuration it was spawned with.
+		require.NoError(t, child.Shutdown(ctx))
+		require.False(t, child.IsRunning())
+		require.False(t, child.IsRelocatable())
+
+		require.NoError(t, parent.Shutdown(ctx))
+		require.False(t, parent.IsRelocatable())
+
+		require.NoError(t, actorSystem.Stop(ctx))
+	})
+
+	t.Run("singleton flag survives shutdown", func(t *testing.T) {
+		ctx := context.TODO()
+		sys, err := NewActorSystem("testSys", WithLogger(log.DiscardLogger))
+		require.NoError(t, err)
+		require.NoError(t, sys.Start(ctx))
+
+		actorSystem := sys.(*actorSystem)
+		pid, err := actorSystem.configPID(ctx, "singleton", NewMockActor(), WithLongLived(), withSingleton(&singletonSpec{}))
+		require.NoError(t, err)
+		require.NotNil(t, pid)
+		require.True(t, pid.IsSingleton())
+
+		require.NoError(t, pid.Shutdown(ctx))
+		require.False(t, pid.IsRunning())
+		require.True(t, pid.IsSingleton())
+
+		require.NoError(t, sys.Stop(ctx))
+	})
+}
+
+func TestRestartPreservesSpawnTimeConfiguration(t *testing.T) {
+	t.Run("relocation stays disabled after restart when disabled during spawning", func(t *testing.T) {
+		ctx := context.TODO()
+		actorSystem, err := NewActorSystem("testSys", WithLogger(log.DiscardLogger))
+		require.NoError(t, err)
+		require.NoError(t, actorSystem.Start(ctx))
+
+		parent, err := actorSystem.Spawn(ctx, "parent", NewMockActor(), WithLongLived(), WithRelocationDisabled())
+		require.NoError(t, err)
+		require.NotNil(t, parent)
+
+		// child actors are not relocatable
+		child, err := parent.SpawnChild(ctx, "child", NewMockActor(), WithLongLived())
+		require.NoError(t, err)
+		require.NotNil(t, child)
+		require.False(t, child.IsRelocatable())
+
+		require.NoError(t, child.Restart(ctx))
+		require.True(t, child.IsRunning())
+		require.False(t, child.IsRelocatable())
+
+		require.NoError(t, parent.Shutdown(ctx))
+		require.False(t, parent.IsRelocatable())
+
+		require.NoError(t, actorSystem.Stop(ctx))
+	})
+
+	t.Run("relocation stays enabled after restart when enabled during spawning", func(t *testing.T) {
+		ctx := context.TODO()
+		actorSystem, err := NewActorSystem("testSys", WithLogger(log.DiscardLogger))
+		require.NoError(t, err)
+		require.NoError(t, actorSystem.Start(ctx))
+
+		parent, err := actorSystem.Spawn(ctx, "parent", NewMockActor(), WithLongLived())
+		require.NoError(t, err)
+		require.NotNil(t, parent)
+		require.True(t, parent.IsRelocatable())
+
+		require.NoError(t, parent.Restart(ctx))
+		require.True(t, parent.IsRunning())
+		require.True(t, parent.IsRelocatable())
+
+		require.NoError(t, actorSystem.Stop(ctx))
+	})
+}

--- a/docs/actor/relocation.mdx
+++ b/docs/actor/relocation.mdx
@@ -62,7 +62,9 @@ sequenceDiagram
 ### Key steps
 
 1. **preShutdown**: When a node stops, it builds a `PeerState` snapshot of all relocatable actors and grains. Actors
-   with `WithRelocationDisabled` and grains with `WithGrainDisableRelocation` are excluded.
+   with `WithRelocationDisabled` and grains with `WithGrainDisableRelocation` are excluded. Actors that have already
+   been stopped, or whose shutdown is in progress, are excluded as well, even if they have not yet been removed from
+   the actor tree by DeathWatch.
 2. **persistPeerStateToPeers**: Before leaving membership, the node replicates its `PeerState` to **up to 3 oldest**
    cluster peers via RPC (not all remaining peers). The implementation uses `selectOldestPeers(3)` to pick the three
    oldest nodes by `CreatedAt`; if fewer than 3 peers exist, it replicates to all. Replication returns successfully as


### PR DESCRIPTION
closes #1349 